### PR TITLE
fix segfault on log

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -622,7 +622,7 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t * r,
       }
 
       ngx_snprintf(service.value, service.length, "%V/%V@%V%Z",
-              &alcf->srvcname, host_name.data, &alcf->realm);
+              &alcf->srvcname, &host_name, &alcf->realm);
     }
     spnego_debug1("Using service principal: %s", service.value);
 


### PR DESCRIPTION
`host_name` is a `ngx_str_t`. If you want to pass it to `ngx_snprintf` as `%V`, we need to actually pass the structure, not just the char\* inside.
