### PR TITLE
Remove make error: "warning: implicit declaration of function 'error_message'"

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -35,6 +35,7 @@
 #include <gssapi/gssapi.h>
 #include <gssapi/gssapi_krb5.h>
 #include <krb5.h>
+#include <com_err.h>
 
 #define krb5_get_err_text(context,code) error_message(code)
 #define spnego_error(code) ret = code; goto end


### PR DESCRIPTION
"
cc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -I /usr/local/include  -I src/core  -I src/event  -I src/event/modules  -I src/os/unix  -I zlib-1.2.8  -I objs  -I src/http  -I src/http/modules  -I src/mail  -o objs/addon/spnego-http-auth-nginx-module-master/ngx_http_auth_spnego_module.o  spnego-http-auth-nginx-module-master/ngx_http_auth_spnego_module.c
cc1: warnings being treated as errors
spnego-http-auth-nginx-module-master/ngx_http_auth_spnego_module.c: In function 'ngx_http_auth_spnego_basic':
spnego-http-auth-nginx-module-master/ngx_http_auth_spnego_module.c:496: warning: implicit declaration of function 'error_message'
**\* [objs/addon/spnego-http-auth-nginx-module-master/ngx_http_auth_spnego_module.o] Error code 1
"

Remove this error where make nginx configured with "--add-module=spnego-http-auth-nginx-module-master".
