### PR TITLE
add missed handle on NGX_ERROR

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -943,6 +943,10 @@ ngx_http_auth_spnego_handler(
     if (NGX_OK == ret) {
         spnego_debug0("Client sent a reasonable Negotiate header");
         ret = ngx_http_auth_spnego_auth_user_gss(r, ctx, alcf);
+        if (NGX_ERROR == ret) {
+            spnego_debug0("GSSAPI failed");
+            return (ctx->ret = NGX_HTTP_INTERNAL_SERVER_ERROR);
+        }
         /* There are chances that client knows about Negotiate
          * but doesn't support GSSAPI. We could attempt to fall
          * back to basic here... */


### PR DESCRIPTION
NGX_ERROR would be raised when some Kerberos function fails, then module will report the authentication still succeeds.

This patch treats such errors as an internal error. That is, once NGX_ERROR is returned from function ngx_http_auth_spnego_auth_user_gss, module will terminate the authentication process immediately and mark it NGX_HTTP_INTERNAL_SERVER_ERROR.

Debug log generated from current version (v1.0.0 and devel)

```
2015/03/25 10:23:09 [debug] 2758#0: *23 Begin auth
2015/03/25 10:23:09 [debug] 2758#0: *23 Detect basic auth
2015/03/25 10:23:09 [debug] 2758#0: *23 Detect SPNEGO token
2015/03/25 10:23:09 [debug] 2758#0: *23 posix_memalign: 0000000002470780:4096 @16
2015/03/25 10:23:09 [debug] 2758#0: *23 Token decoded: YIIDyAYGKw...
2015/03/25 10:23:09 [debug] 2758#0: *23 Client sent a reasonable Negotiate header
2015/03/25 10:23:09 [debug] 2758#0: *23 GSSAPI authorizing
2015/03/25 10:23:09 [debug] 2758#0: *23 Use keytab /home/cqi/local/nginx/conf/httpd.keytab
2015/03/25 10:23:09 [debug] 2758#0: *23 Using service principal: HTTP/hostname@EXAMPLE.COM
2015/03/25 10:23:09 [debug] 2758#0: *23 my_gss_name HTTP/hostname@EXAMPLE.COM
2015/03/25 10:23:09 [error] 2758#0: *23 gss_acquire_cred() failed: : Used service principal: HTTP/hostname@EXAMPLE.COM, client: 192.168.122.1, server: 192.168.122.249, request: "GET /mysite/ HTTP/1.1", host: "192.168.122.249:8001"
2015/03/25 10:23:09 [debug] 2758#0: *23 GSSAPI auth succeeded
2015/03/25 10:23:09 [debug] 2758#0: *23 SSO auth handling OUT: token.len=972, head=1, ret=500
```

Logs after applying this patch

```
2015/03/25 13:51:13 [debug] 6116#0: *1 Begin auth
2015/03/25 13:51:13 [debug] 6116#0: *1 Detect basic auth
2015/03/25 13:51:13 [debug] 6116#0: *1 Detect SPNEGO token
2015/03/25 13:51:13 [debug] 6116#0: *1 posix_memalign: 00000000017C7EB0:4096 @16
2015/03/25 13:51:13 [debug] 6116#0: *1 Token decoded: YIIDyAYG...
2015/03/25 13:51:13 [debug] 6116#0: *1 Client sent a reasonable Negotiate header
2015/03/25 13:51:13 [debug] 6116#0: *1 GSSAPI authorizing
2015/03/25 13:51:13 [debug] 6116#0: *1 Use keytab /home/cqi/local/nginx/conf/httpd.keytab
2015/03/25 13:51:13 [debug] 6116#0: *1 Using service principal: HTTP/hostname@EXAMPLE.COM
2015/03/25 13:51:13 [debug] 6116#0: *1 my_gss_name HTTP/hostname@EXAMPLE.COM
2015/03/25 13:51:13 [error] 6116#0: *1 gss_acquire_cred() failed: : Used service principal: HTTP/hostname@EXAMPLE.COM, client: 192.168.122.1, server: 192.168.122.249, request: "GET /mysite HTTP/1.1", host: "192.168.122.249:8001"
2015/03/25 13:51:13 [debug] 6116#0: *1 GSSAPI failed
2015/03/25 13:51:13 [debug] 6116#0: *1 http finalize request: 500, "/mysite?" a:1, c:1
2015/03/25 13:51:13 [debug] 6116#0: *1 http special response: 500, "/mysite?"
2015/03/25 13:51:13 [debug] 6116#0: *1 http set discard body
2015/03/25 13:51:13 [debug] 6116#0: *1 HTTP/1.1 500 Internal Server Error
Server: nginx/1.6.2
Date: Wed, 25 Mar 2015 05:51:13 GMT
Content-Type: text/html
Content-Length: 192
Connection: close
```