### PR TITLE
Improve basic authentication and clarify semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,6 @@ multiple entries, one per line.
     auth_gss_authorized_principal <username>@<realm>
     auth_gss_authorized_principal <username2>@<realm>
 
-If you are using SPNEGO without SSL, it is recommended you disable basic
-authentication fallback, as the password would be sent in plaintext.  This
-is done by setting `auth_gss_allow_basic_fallback` in the config file.
-
-    auth_gss_allow_basic_fallback off
-
 The remote user header in nginx can only be set by doing basic authentication.
 Thus, this module sets a bogus basic auth header that will reach your backend
 application in order to set this header/nginx variable.  The easiest way to disable
@@ -74,6 +68,28 @@ this behavior is to add the following configuration to your location config.
     
 A future version of the module may make this behavior an option, but this should
 be a sufficient workaround for now.
+
+Basic authentication fallback
+-----------------------------
+
+The module falls back to basic authentication by default if no negotiation is
+attempted by the client.  If you are using SPNEGO without SSL, it is recommended
+you disable basic authentication fallback, as the password would be sent in
+plaintext.  This is done by setting `auth_gss_allow_basic_fallback` in the
+config file.
+
+    auth_gss_allow_basic_fallback off
+
+These options affect the operation of basic authentication:
+* `auth_gss_realm`: Kerberos realm name.  If this is specified, the realm is
+  only passed to the nginx variable $remote_user if it differs from this
+  default.  To override this behavior, set *auth_gss_format_full* to 1 in your
+  configuration.
+* `auth_gss_force_realm`: Forcibly authenticate using the realm configured in
+  `auth_gss_realm` or the system default realm if `auth_gss_realm` is not set.
+  This will rewrite $remote_user if the client provided a different realm.  If
+  *auth_gss_format_full* is not set, $remote_user will not include a realm even
+  if one was specified by the client.
 
 
 Troubleshooting


### PR DESCRIPTION
Fixes a number of shortcomings in the fallback basic authentication
code and documentation:

  o Document the behaviour of auth_gss_force_realm
  o Make auth_gss_format_full behave consistently
  o Never copy a trailing \0 into $remote_user
  o Plug two small memory leaks

Arguably, basic authentication should return NGX_DECLINED when
auth_gss_force_realm is configured and a different realm is given,
but preserve the original behaviour in case anyone relies on that.