### PR TITLE
Fix build for MIT Kerberos

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -633,7 +633,16 @@ ngx_http_auth_spnego_basic(
 
     /* Try to add the system realm to $remote_user if needed. */
     if (alcf->fqun && !ngx_strchr(r->headers_in.user.data, '@')) {
+#ifdef krb5_princ_realm
+        /*
+         * MIT does not have krb5_principal_get_realm() but its
+         * krb5_princ_realm() is a macro that effectively points
+         * to a char *.
+         */
+        const char *realm = krb5_princ_realm(kcontext, client)->data;
+#else
 	const char *realm = krb5_principal_get_realm(kcontext, client);
+#endif
 	if (realm) {
 	    new_user.len = r->headers_in.user.len + 1 + ngx_strlen(realm);
 	    new_user.data = ngx_palloc(r->pool, new_user.len);


### PR DESCRIPTION
It's been pointed out to me that krb5_principal_get_realm() only exists in Heimdal.  Sorry for the breakage.  I only tested my original patch against Heimdal.  I tested this against MIT as well.