### PR TITLE
Return NGX_HTTP_UNAUTHORIZED if Basic auth failed

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -993,7 +993,7 @@ ngx_http_auth_spnego_handler(
              * not fall through to real SPNEGO */
             if (NGX_DECLINED == ngx_http_auth_spnego_basic(r, ctx, alcf)) {
                 spnego_debug0("Basic auth failed");
-                return (ctx->ret = NGX_HTTP_FORBIDDEN);
+                return (ctx->ret = NGX_HTTP_UNAUTHORIZED);
             }
 
             if (!ngx_spnego_authorized_principal(r, &r->headers_in.user, alcf)) {


### PR DESCRIPTION
Returning NGX_HTTP_FORBIDDEN if the credentials provided are wrong results in a state where the browser thinks the credentials provided are valid but the resource it's trying to access is not accessible by the user, changing  NGX_HTTP_FORBIDDEN to NGX_HTTP_UNAUTHORIZED let the browser know the credentials provided are wrong, asking for them again.
The problem and the solution is described here #67 