### PR TITLE
Add support for GSS localname rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ this behavior is to add the following configuration to your location config.
 A future version of the module may make this behavior an option, but this should
 be a sufficient workaround for now.
 
+If you would like to enable GSS local name rules to rewrite usernames, you can
+specify the `auth_gss_map_to_local` option.
+
 Basic authentication fallback
 -----------------------------
 

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -37,6 +37,7 @@
 #include <krb5.h>
 #include <com_err.h>
 
+#define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
 
 #define spnego_log_krb5_error(context,code) {\
     const char* ___kerror = krb5_get_error_message(context, code);\
@@ -114,6 +115,7 @@ typedef struct {
     ngx_flag_t force_realm;
     ngx_flag_t allow_basic;
     ngx_array_t *auth_princs;
+    ngx_flag_t map_to_local;
 } ngx_http_auth_spnego_loc_conf_t;
 
 #define SPNEGO_NGX_CONF_FLAGS NGX_HTTP_MAIN_CONF\
@@ -180,6 +182,13 @@ static ngx_command_t ngx_http_auth_spnego_commands[] = {
         offsetof(ngx_http_auth_spnego_loc_conf_t, auth_princs),
         NULL},
 
+    {ngx_string("auth_gss_map_to_local"),
+        SPNEGO_NGX_CONF_FLAGS,
+        ngx_conf_set_flag_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_auth_spnego_loc_conf_t, map_to_local),
+        NULL},
+
     ngx_null_command
 };
 
@@ -230,6 +239,7 @@ ngx_http_auth_spnego_create_loc_conf(
     conf->force_realm = NGX_CONF_UNSET;
     conf->allow_basic = NGX_CONF_UNSET;
     conf->auth_princs = NGX_CONF_UNSET_PTR;
+    conf->map_to_local = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -256,6 +266,8 @@ ngx_http_auth_spnego_merge_loc_conf(
     ngx_conf_merge_off_value(conf->allow_basic, prev->allow_basic, 1);
     ngx_conf_merge_ptr_value(conf->auth_princs, prev->auth_princs, NGX_CONF_UNSET_PTR);
 
+    ngx_conf_merge_off_value(conf->map_to_local, prev->map_to_local, 0);
+
 #if (NGX_DEBUG)
     ngx_conf_log_error(NGX_LOG_INFO, cf, 0, "auth_spnego: protect = %i",
             conf->protect);
@@ -277,6 +289,8 @@ ngx_http_auth_spnego_merge_loc_conf(
                     "auth_spnego: auth_princs = %.*s", auth_princs[ii].len, auth_princs[ii].data);
         }
     }
+    ngx_conf_log_error(NGX_LOG_INFO, cf, 0, "auth_spnego: map_to_local = %i",
+            conf->map_to_local);
 #endif
 
     return NGX_CONF_OK;
@@ -882,7 +896,6 @@ ngx_http_auth_spnego_auth_user_gss(
 
     /* getting user name at the other end of the request */
     major_status = gss_display_name(&minor_status, client_name, &output_token, NULL);
-    gss_release_name(&minor_status, &client_name);
     if (GSS_ERROR(major_status)) {
         spnego_log_error("%s", get_gss_error(r->pool, minor_status,
                     "gss_display_name() failed"));
@@ -890,6 +903,19 @@ ngx_http_auth_spnego_auth_user_gss(
     }
 
     if (output_token.length) {
+        /* Apply local rules to map Kerberos Principals to short names */
+        if (alcf->map_to_local) {
+            gss_OID mech_type = discard_const(gss_mech_krb5);
+            output_token = (gss_buffer_desc) GSS_C_EMPTY_BUFFER;
+            major_status = gss_localname(&minor_status, client_name,
+                    mech_type, &output_token);
+            if (GSS_ERROR(major_status)) {
+                spnego_log_error("%s", get_gss_error(r->pool, minor_status,
+                            "gss_localname() failed"));
+                spnego_error(NGX_ERROR);
+            }
+        }
+
         /* TOFIX dirty quick trick for now (no "-1" i.e. include '\0' */
         ngx_str_t user = {
             output_token.length,


### PR DESCRIPTION
Hi there, 

This PR adds a flag `auth_gss_map_to_local` to take into account the GSS local name rules that rewrite usernames.

We've been running this in our prod environment for a few weeks and it behaves as expected.

Inspired by the Apache implementation:
https://github.com/modauthgssapi/mod_auth_gssapi/blob/master/src/mod_auth_gssapi.c#L1274

Let me know if that looks good to you. 
Thanks!