### PR TITLE
Add Windows/AD and UNIX commands and configuration to generate and use Keytabs with nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This module implements adds [SPNEGO](http://tools.ietf.org/html/rfc4178)
 support to nginx(http://nginx.org).  It currently supports only Kerberos
 authentication via [GSSAPI](http://en.wikipedia.org/wiki/GSSAPI)
 
+Purpose of this fork
+--------------------
+
+This fork is abandoned. Please use the original source: http://github.com/stnoonan/spnego-http-auth-nginx-module
 
 Prerequisites
 -------------

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ application in order to set this header/nginx variable.  The easiest way to disa
 this behavior is to add the following configuration to your location config.
 
     proxy_set_header Authorization "";
-    
+
 A future version of the module may make this behavior an option, but this should
 be a sufficient workaround for now.
 
@@ -158,8 +158,141 @@ Note that the module does not support [NTLMSSP](http://en.wikipedia.org/wiki/NTL
 in Negotiate. NTLM, both v1 and v2, is an exploitable protocol and should be avoided
 where possible.
 
+Ubuntu 12.04 LTS packages for the latest version of Nginx compiled with the SPNEGO module
+are [available in this PPA](https://launchpad.net/~bcandrea/+archive/nginx-stable).
+
+
+Crash course to Windows KDC Configuration
+-----------------------------------------
+
+On the AD side, you need to:
+
+* Create a new user, whose name should be the service name you'll be using
+  Kerberos authentication on. E.g. `app.example`.
+* Set the "User cannot change password" and "Password never expires" options
+  on the account
+* Set a strong password on it
+* From a Windows `cmd.exe` window, generate the service principals and keytabs
+  for this user.  You need an SPN named `host/foo.example.com`, and another
+  named `HTTP/foo.example.com`. It is crucial that `foo.example.com` is the
+  DNS name of your web site in the intranet, and it is an `A` record.  Given
+  that `app.example` is the account name you created, you would execute:
+
+        C:\> ktpass -princ host/foo.example.com@EXAMPLE.COM -mapuser
+        EXAMPLECOM\app.example -pass * -out host.keytab -ptype KRB5_NT_PRINCIPAL
+
+        C:\> ktpass -princ HTTP/foo.example.com@EXAMPLE.COM -mapuser
+        EXAMPLECOM\app.example -pass * -out http.keytab -ptype KRB5_NT_PRINCIPAL
+
+* Verify that the correct SPNs are created:
+
+        C:\> setspn -Q */foo.example.com
+
+  it should yield both the `HTTP/` and `host/` SPNs, both mapped to the
+  `app.example` user.
+
+
+Crash course to UNIX KRB5 and nginx configuration
+-------------------------------------------------
+
+* Verify that your UNIX machine is using the same DNS server as your DC, most
+  likely it'll use the DC itself.
+
+* Create an /etc/krb5.conf configuration file, replacing the realm and kdc
+  host names with your own AD setup:
+
+        [libdefaults]
+          default_tkt_enctypes = arcfour-hmac-md5
+          default_tgs_enctypes = arcfour-hmac-md5
+          default_keytab_name  = FILE:/etc/krb5.keytab
+          default_realm        = EXAMPLE.COM
+          ticket_lifetime      = 24h
+          kdc_timesync         = 1
+          ccache_type          = 4
+          forwardable          = false
+          proxiable            = false
+
+        [realms]
+          EXAMPLE.COM = {
+              kdc            = dc.example.com
+              admin_server   = dc.example.com
+              default_domain = example.com
+          }
+
+        [domain_realm]
+          .kerberos.server = EXAMPLE.COM
+          .example.com     = EXAMPLE.COM
+
+* Copy the two keytab files (`host.keytab` and `http.keytab`) created with
+  ktpass on Windows to your UNIX machine.
+
+* Create a krb5.keytab using ktutil, concatenating together the two SPNs keytabs:
+
+        # ktutil
+        ktutil:  rkt host.keytab
+        ktutil:  rkt http.keytab
+        ktutil:  wkt /etc/krb5.keytab
+        ktutil:  quit
+
+* Verify that the created keytab file has been built correctly:
+
+        # klist -kt /etc/krb5.keytab
+        Keytab name: WRFILE:/etc/krb5.keytab
+        KVNO Timestamp         Principal
+        ---- ----------------- --------------------------------------------------------
+        9 02/19/13 04:02:48 HTTP/foo.example.com@EXAMPLE.COM
+        8 02/19/13 04:02:48 host/foo.example.com@EXAMPLE.COM
+
+  Key version numbers (`KVNO`) will be different in your case.
+
+
+* Verify that you are able to authenticate using the keytab, without password:
+
+        # kinit -5 -V -k -t /etc/krb5.keytab HTTP/foo.example.com
+        Authenticated to Kerberos v5
+
+        # klist
+        Ticket cache: FILE:/tmp/krb5cc_0
+        Default principal: HTTP/foo.example.com@EXAMPLE.COM
+
+        Valid starting     Expires            Service principal
+        02/19/13 17:37:42  02/20/13 03:37:40  krbtgt/EXAMPLE.COM@EXAMPLE.COM
+                renew until 02/20/13 17:37:42
+
+* Make the keytab file accessible only by root and the nginx group:
+
+        # chmod 440 /etc/krb5.keytab
+        # chown root:nginx /etc/krb5.keytab
+
+* Configure a SPNEGO-protected location in the nginx configuration file:
+
+        server {
+          server_name foo.example.com;
+
+          ssl on;
+          ssl_certificate     example.com.crt;
+          ssl_certificate_key example.com.crt;
+
+          location / {
+            root /some/where;
+            index index.html;
+            auth_gss on;
+            auth_gss_realm EXAMPLE.COM;
+            auth_gss_keytab /etc/krb5.keytab;
+            auth_gss_service_name HTTP;
+          }
+        }
+
+  The SPN will be built as follows:
+
+        $auth_gss_service_name / $server_name @ $auth_gss_realm
+
+  In the above example, it'll be `HTTP/foo.example.com@EXAMPLE.COM`. You can
+  specify a fully-qualified SPN in the `auth_gss_service_name` configuration
+  option, in this case the `server_name` won't be added automatically.
+
 Help
 ----
 
-If you're unable to figure things out, please feel free to open an 
+If you're unable to figure things out, please feel free to open an
 issue on Github and I'll do my best to help you.


### PR DESCRIPTION
Dear @stnoonan -

first, thanks for your work on this nginx module, that has proven very robust and reliable in the last 5 years it has been in production for us.

This pull is for discussion only, as it contains only README changes on how to obtain a Windows service account mapped to specific service names that are not dependant on the system's host name where nginx is running.

The scenario here is that you may have multiple boxes with nginx on them serving the same app, say, "foo.example.com", behind a load balancer. The nginx servers need to have a keytab that has both the `host/foo.example.com` and `HTTP/foo.example.com`, and on the AD side the service account used for Kerberos authentication need to have these two SPNs mapped to it, in the very same "host/" first and "HTTP/" after order.

It is also possible to have different service names mapped to the same service account, as long as the `host/` and `HTTP/` entries in the Windows SPN database are in the right order.

The documentation in this pull shows all the steps required to achieve the above, that allow for great flexibility and that has been tested with AD on Windows Server 2008, 2012, 2016 and with both IE 11 and Chrome on Windows 7 and Windows 10.

Thanks for your time,