### PR TITLE
Retry basic auth if entered credentials are invalid

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -985,6 +985,14 @@ ngx_http_auth_spnego_handler(
              * not fall through to real SPNEGO */
             if (NGX_DECLINED == ngx_http_auth_spnego_basic(r, ctx, alcf)) {
                 spnego_debug0("Basic auth failed");
+
+                /* Set headers for retry auth */
+                ngx_str_t *token_out_b64 = NULL;
+                if (NGX_ERROR == ngx_http_auth_spnego_headers(r, ctx, token_out_b64, alcf)) {
+                    spnego_debug0("Error setting headers");
+                    ctx->ret = NGX_HTTP_INTERNAL_SERVER_ERROR;
+                }
+
                 return (ctx->ret = NGX_HTTP_UNAUTHORIZED);
             }
 


### PR DESCRIPTION
If the basic auth mode is active, the user will be prompted for credentials until they are correct.