### PR TITLE
Removed the #include of com_err.h because it wasn't used

### DIFF
--- a/config
+++ b/config
@@ -5,6 +5,10 @@ if uname -o | grep -q FreeBSD; then
     ngx_feature_libs="$ngx_feature_libs -lgssapi"
 fi
 
+if uname -a | grep -q NetBSD; then
+    ngx_feature_libs="-lgssapi -lkrb5 -lcom_err"
+fi
+
 if test -n "$ngx_module_link"; then
     ngx_module_type=HTTP
     ngx_module_name=ngx_http_auth_spnego_module

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -35,7 +35,6 @@
 #include <gssapi/gssapi.h>
 #include <gssapi/gssapi_krb5.h>
 #include <krb5.h>
-#include <com_err.h>
 
 
 #define spnego_log_krb5_error(context,code) {\


### PR DESCRIPTION
I tested this with Heimdal Kerberos on a BSD system and one problem I found was that com_err.h doesn't exist in Heimdal. 

I removed the #include and then tested it on Ubuntu 18.04.4 LTS and the code compiled fine there, so I'm going to guess that your code doesn't need com_err.h.
