### PR TITLE
Add support for unconstrained delegation, constrained delegation, and auth_gss_authorized_principal_regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ User credentials can be delegated to nginx using the `auth_gss_delegate_credenti
  directive. This directive will enable unconstrained delegation if the user chooses 
  to delegate their credentials. Constrained delegation (S4U2proxy) can also be enabled using the 
  `auth_gss_constrained_delegation` directive together with the `auth_gss_delegate_credentials` 
- directive. To specify the ccache file name to store the service ticket used for constrained  
+ directive. To specify the ccache file name to store the service ticket used for constrained 
  delegation, set the `auth_gss_service_ccache` directive. Otherwise, the default ccache name will 
  be used.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ multiple entries, one per line.
     auth_gss_authorized_principal <username>@<realm>
     auth_gss_authorized_principal <username2>@<realm>
 
+Users can also be authorized using a regex pattern via the `auth_gss_authorized_principal_regex`
+ directive. This directive can be used together with the `auth_gss_authorized_principal` directive.
+
+    auth_gss_authorized_principal <username>@<realm>
+    auth_gss_authorized_principal_regex ^(<username>)/(<group>)@<realm>$
+
 The remote user header in nginx can only be set by doing basic authentication.
 Thus, this module sets a bogus basic auth header that will reach your backend
 application in order to set this header/nginx variable.  The easiest way to disable
@@ -71,6 +77,28 @@ be a sufficient workaround for now.
 
 If you would like to enable GSS local name rules to rewrite usernames, you can
 specify the `auth_gss_map_to_local` option.
+
+Credential Delegation
+-----------------------------
+
+User credentials can be delegated to nginx using the `auth_gss_delegate_credentials` 
+ directive. This directive will enable unconstrained delegation if the user chooses 
+ to delegate their credentials. Constrained delegation (S4U2proxy) can also be enabled using the 
+ `auth_gss_constrained_delegation` directive together with the `auth_gss_delegate_credentials` 
+ directive. To specify the ccache file name to store the service ticket used for constrained  
+ delegation, set the `auth_gss_service_ccache` directive. Otherwise, the default ccache name will 
+ be used.
+
+    auth_gss_service_ccache /tmp/krb5cc_0;
+    auth_gss_delegate_credentials on;
+    auth_gss_constrained_delegation on;
+
+The delegated credentials will be stored within the systems tmp directory. Once the
+ request is completed, the credentials file will be destroyed. The mame of the credentials 
+ file will be specified within the nginx variable `$krb5_cc_name`. Usage of the variable 
+ can include passing it to a fcgi program using the `fastcgi_param` directive.
+
+    fastcgi_param KRB5CCNAME $krb5_cc_name;
 
 Basic authentication fallback
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ User credentials can be delegated to nginx using the `auth_gss_delegate_credenti
  directive. This directive will enable unconstrained delegation if the user chooses 
  to delegate their credentials. Constrained delegation (S4U2proxy) can also be enabled using the 
  `auth_gss_constrained_delegation` directive together with the `auth_gss_delegate_credentials` 
- directive.To specify the ccache file name to store the service ticket used for constrained 
+ directive. To specify the ccache file name to store the service ticket used for constrained 
  delegation, set the `auth_gss_service_ccache` directive. Otherwise, the default ccache name 
  will be used.
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,9 @@ User credentials can be delegated to nginx using the `auth_gss_delegate_credenti
  directive. This directive will enable unconstrained delegation if the user chooses 
  to delegate their credentials. Constrained delegation (S4U2proxy) can also be enabled using the 
  `auth_gss_constrained_delegation` directive together with the `auth_gss_delegate_credentials` 
- directive. Constrained delegation is currently only supported using the negotiate authentication 
- scheme and has been tested with MIT Kerberos (Use at your own risk is using Heimdal Kerberos). 
- To specify the ccache file name to store the service ticket used for constrained delegation, 
- set the `auth_gss_service_ccache` directive. Otherwise, the default ccache name will 
- be used.
+ directive.To specify the ccache file name to store the service ticket used for constrained 
+ delegation, set the `auth_gss_service_ccache` directive. Otherwise, the default ccache name 
+ will be used.
 
     auth_gss_service_ccache /tmp/krb5cc_0;
     auth_gss_delegate_credentials on;
@@ -101,6 +99,9 @@ The delegated credentials will be stored within the systems tmp directory. Once 
  can include passing it to a fcgi program using the `fastcgi_param` directive.
 
     fastcgi_param KRB5CCNAME $krb5_cc_name;
+
+Constrained delegation is currently only supported using the negotiate authentication scheme
+ and has only been testing with MIT Kerberos (Use at your own risk if using Heimdal Kerberos).
 
 Basic authentication fallback
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ User credentials can be delegated to nginx using the `auth_gss_delegate_credenti
  directive. This directive will enable unconstrained delegation if the user chooses 
  to delegate their credentials. Constrained delegation (S4U2proxy) can also be enabled using the 
  `auth_gss_constrained_delegation` directive together with the `auth_gss_delegate_credentials` 
- directive. To specify the ccache file name to store the service ticket used for constrained 
- delegation, set the `auth_gss_service_ccache` directive. Otherwise, the default ccache name will 
+ directive. Constrained delegation is currently only supported using the negotiate authentication 
+ scheme and has been tested with MIT Kerberos (Use at your own risk is using Heimdal Kerberos). 
+ To specify the ccache file name to store the service ticket used for constrained delegation, 
+ set the `auth_gss_service_ccache` directive. Otherwise, the default ccache name will 
  be used.
 
     auth_gss_service_ccache /tmp/krb5cc_0;

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ User credentials can be delegated to nginx using the `auth_gss_delegate_credenti
     auth_gss_constrained_delegation on;
 
 The delegated credentials will be stored within the systems tmp directory. Once the
- request is completed, the credentials file will be destroyed. The mame of the credentials 
+ request is completed, the credentials file will be destroyed. The name of the credentials 
  file will be specified within the nginx variable `$krb5_cc_name`. Usage of the variable 
  can include passing it to a fcgi program using the `fastcgi_param` directive.
 

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -36,6 +36,12 @@
 #include <gssapi/gssapi_krb5.h>
 #include <krb5.h>
 
+#include <time.h>
+
+#define CCACHE_VARIABLE_NAME "krb5_cc_name"
+#define SHM_ZONE_NAME "shm_zone"
+#define RENEWAL_TIME 60
+
 #define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
 
 #define spnego_log_krb5_error(context,code) {\
@@ -62,8 +68,11 @@ static char *ngx_http_auth_spnego_merge_loc_conf(
         ngx_conf_t *, void *, void *);
 static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *);
 
-ngx_int_t
-ngx_http_auth_spnego_set_bogus_authorization(ngx_http_request_t * r);
+#if (NGX_PCRE)	
+static char * ngx_conf_set_regex_array_slot(ngx_conf_t * cf, ngx_command_t * cmd, void * conf);
+#endif
+
+ngx_int_t ngx_http_auth_spnego_set_bogus_authorization(ngx_http_request_t * r);
 
     const char *
 get_gss_error(
@@ -97,6 +106,18 @@ get_gss_error(
     return (char *) (ngx_pstrdup(p, &str));
 }
 
+static ngx_shm_zone_t * shm_zone;
+
+typedef enum {
+	TYPE_KRB5_CREDS,
+	TYPE_GSS_CRED_ID_T
+} creds_type;
+
+typedef struct {
+	void * data;
+	creds_type type;
+} creds_info;
+
 /* per request/connection */
 typedef struct {
     ngx_str_t token; /* decoded Negotiate token */
@@ -109,12 +130,18 @@ typedef struct {
     ngx_flag_t protect;
     ngx_str_t realm;
     ngx_str_t keytab;
+	ngx_str_t service_ccache;
     ngx_str_t srvcname;
     ngx_flag_t fqun;
     ngx_flag_t force_realm;
     ngx_flag_t allow_basic;
-    ngx_array_t *auth_princs;
+    ngx_array_t * auth_princs;
+#if (NGX_PCRE)
+	ngx_array_t * auth_princs_regex;
+#endif
     ngx_flag_t map_to_local;
+    ngx_flag_t delegate_credentials;
+    ngx_flag_t constrained_delegation;
 } ngx_http_auth_spnego_loc_conf_t;
 
 #define SPNEGO_NGX_CONF_FLAGS NGX_HTTP_MAIN_CONF\
@@ -144,6 +171,13 @@ static ngx_command_t ngx_http_auth_spnego_commands[] = {
         ngx_conf_set_str_slot,
         NGX_HTTP_LOC_CONF_OFFSET,
         offsetof(ngx_http_auth_spnego_loc_conf_t, keytab),
+        NULL},
+		
+    {ngx_string("auth_gss_service_ccache"),
+        SPNEGO_NGX_CONF_FLAGS,
+        ngx_conf_set_str_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_auth_spnego_loc_conf_t, service_ccache),
         NULL},
 
     {ngx_string("auth_gss_service_name"),
@@ -180,12 +214,33 @@ static ngx_command_t ngx_http_auth_spnego_commands[] = {
         NGX_HTTP_LOC_CONF_OFFSET,
         offsetof(ngx_http_auth_spnego_loc_conf_t, auth_princs),
         NULL},
-
+#if (NGX_PCRE)		
+    {ngx_string("auth_gss_authorized_principal_regex"),
+        SPNEGO_NGX_CONF_FLAGS | NGX_CONF_1MORE,
+        ngx_conf_set_regex_array_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_auth_spnego_loc_conf_t, auth_princs_regex),
+        NULL},
+#endif
     {ngx_string("auth_gss_map_to_local"),
         SPNEGO_NGX_CONF_FLAGS,
         ngx_conf_set_flag_slot,
         NGX_HTTP_LOC_CONF_OFFSET,
         offsetof(ngx_http_auth_spnego_loc_conf_t, map_to_local),
+        NULL},
+    
+    {ngx_string("auth_gss_delegate_credentials"),
+	SPNEGO_NGX_CONF_FLAGS,
+        ngx_conf_set_flag_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_auth_spnego_loc_conf_t, delegate_credentials),
+        NULL},
+
+    {ngx_string("auth_gss_constrained_delegation"),
+        SPNEGO_NGX_CONF_FLAGS,
+        ngx_conf_set_flag_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_auth_spnego_loc_conf_t, constrained_delegation),
         NULL},
 
     ngx_null_command
@@ -222,6 +277,55 @@ ngx_module_t ngx_http_auth_spnego_module = {
     /* uintptr_t spare_hook{0-7}; */
 };
 
+#if (NGX_PCRE)
+static char * ngx_conf_set_regex_array_slot(ngx_conf_t * cf, ngx_command_t * cmd, void * conf){
+	char * p = conf;
+	u_char errstr[NGX_MAX_CONF_ERRSTR];
+	ngx_str_t * value;
+	ngx_regex_elt_t * re;
+	ngx_regex_compile_t rc;
+	ngx_array_t ** a;
+	ngx_conf_post_t * post;
+	
+	a = (ngx_array_t **) (p + cmd->offset);
+	
+	if (*a == NGX_CONF_UNSET_PTR) {
+		*a = ngx_array_create(cf->pool, 4, sizeof(ngx_regex_elt_t));
+		if (*a == NULL) {
+			return NGX_CONF_ERROR;
+		}
+	}
+
+	re = ngx_array_push(*a);
+	if (re == NULL) {
+		return NGX_CONF_ERROR;
+	}
+	
+	value = cf->args->elts;
+	
+	ngx_memzero(&rc, sizeof(ngx_regex_compile_t));
+	
+	rc.pattern = value[1];
+	rc.pool = cf->pool;
+	rc.err.len = NGX_MAX_CONF_ERRSTR;
+	rc.err.data = errstr;
+	
+	if(ngx_regex_compile(&rc) != NGX_OK) {
+		return NGX_CONF_ERROR;
+	}
+	
+	re->regex = rc.regex;
+	re->name = value[1].data;
+	
+	if (cmd->post) {
+		post = cmd->post;
+		return post->post_handler(cf, post, re);
+	}
+	
+	return NGX_CONF_OK;
+}
+#endif
+
     static void *
 ngx_http_auth_spnego_create_loc_conf(
         ngx_conf_t * cf)
@@ -238,7 +342,10 @@ ngx_http_auth_spnego_create_loc_conf(
     conf->force_realm = NGX_CONF_UNSET;
     conf->allow_basic = NGX_CONF_UNSET;
     conf->auth_princs = NGX_CONF_UNSET_PTR;
+	conf->auth_princs_regex = NGX_CONF_UNSET_PTR;
     conf->map_to_local = NGX_CONF_UNSET;
+    conf->delegate_credentials = NGX_CONF_UNSET;
+    conf->constrained_delegation = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -256,16 +363,23 @@ ngx_http_auth_spnego_merge_loc_conf(
     ngx_conf_merge_off_value(conf->protect, prev->protect, 0);
 
     ngx_conf_merge_str_value(conf->realm, prev->realm, "");
-    ngx_conf_merge_str_value(conf->keytab, prev->keytab,
-            "/etc/krb5.keytab");
+    ngx_conf_merge_str_value(conf->keytab, prev->keytab, "/etc/krb5.keytab");
+			
+	ngx_conf_merge_str_value(conf->service_ccache, prev->service_ccache, "");
+			
     ngx_conf_merge_str_value(conf->srvcname, prev->srvcname, "");
 
     ngx_conf_merge_off_value(conf->fqun, prev->fqun, 0);
     ngx_conf_merge_off_value(conf->force_realm, prev->force_realm, 0);
     ngx_conf_merge_off_value(conf->allow_basic, prev->allow_basic, 1);
+	
     ngx_conf_merge_ptr_value(conf->auth_princs, prev->auth_princs, NGX_CONF_UNSET_PTR);
-
+    ngx_conf_merge_ptr_value(conf->auth_princs_regex, prev->auth_princs_regex, NGX_CONF_UNSET_PTR);
+	
     ngx_conf_merge_off_value(conf->map_to_local, prev->map_to_local, 0);
+
+    ngx_conf_merge_off_value(conf->delegate_credentials, prev->delegate_credentials, 0);
+    ngx_conf_merge_off_value(conf->constrained_delegation, prev->constrained_delegation, 0);
 
 #if (NGX_DEBUG)
     ngx_conf_log_error(NGX_LOG_INFO, cf, 0, "auth_spnego: protect = %i",
@@ -275,6 +389,9 @@ ngx_http_auth_spnego_merge_loc_conf(
     ngx_conf_log_error(NGX_LOG_INFO, cf, 0,
             "auth_spnego: keytab@0x%p = %s", conf->keytab.data,
             conf->keytab.data);
+	ngx_conf_log_error(NGX_LOG_INFO, cf, 0,
+            "auth_spnego: service_ccache@0x%p = %s", conf->service_ccache.data,
+            conf->service_ccache.data);
     ngx_conf_log_error(NGX_LOG_INFO, cf, 0,
             "auth_spnego: srvcname@0x%p = %s",
             conf->srvcname.data, conf->srvcname.data);
@@ -284,6 +401,7 @@ ngx_http_auth_spnego_merge_loc_conf(
             conf->allow_basic);
     ngx_conf_log_error(NGX_LOG_INFO, cf, 0, "auth_spnego: force_realm = %i",
             conf->force_realm);
+			
     if (NGX_CONF_UNSET_PTR != conf->auth_princs) {
         size_t ii = 0;
         ngx_str_t *auth_princs = conf->auth_princs->elts;
@@ -292,11 +410,85 @@ ngx_http_auth_spnego_merge_loc_conf(
                     "auth_spnego: auth_princs = %.*s", auth_princs[ii].len, auth_princs[ii].data);
         }
     }
+	
+#if (NGX_PCRE)	
+	if (NGX_CONF_UNSET_PTR != conf->auth_princs_regex){
+		size_t ii = 0;
+        ngx_regex_elt_t * auth_princs_regex = conf->auth_princs_regex->elts;
+        for (; ii < conf->auth_princs_regex->nelts; ++ii) {
+            ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0,
+                    "auth_spnego: auth_princs_regex = %.*s", ngx_strlen(auth_princs_regex[ii].name), auth_princs_regex[ii].name);
+        }
+	}
+#endif
+	
     ngx_conf_log_error(NGX_LOG_INFO, cf, 0, "auth_spnego: map_to_local = %i",
             conf->map_to_local);
+
+    ngx_conf_log_error(NGX_LOG_INFO, cf, 0, "auth_spnego: delegate_credentials = %i",
+            conf->delegate_credentials);
+
+    ngx_conf_log_error(NGX_LOG_INFO, cf, 0, "auth_spnego: constrained_delegation = %i",
+            conf->constrained_delegation);
 #endif
 
     return NGX_CONF_OK;
+}
+
+static ngx_int_t ngx_http_auth_spnego_get_handler(ngx_http_request_t * r, ngx_http_variable_value_t * v, uintptr_t data){ return NGX_OK; }
+
+static ngx_int_t ngx_http_auth_spnego_set_variable(ngx_http_request_t * r, ngx_str_t * name, ngx_str_t * value){
+	u_char * lowercase = ngx_palloc(r->pool, name->len);
+		
+	ngx_uint_t key = ngx_hash_strlow(lowercase, name->data, name->len);	
+	ngx_pfree(r->pool, lowercase);
+	
+	ngx_http_variable_value_t * v = ngx_http_get_variable(r, name, key);
+		
+	if(v == NULL){
+		return NGX_ERROR;
+	}
+	
+	v->len = value->len;
+	v->data = value->data;
+		
+	return NGX_OK;
+}
+
+static ngx_int_t ngx_http_auth_spnego_add_variable(ngx_conf_t * cf, ngx_str_t * name){	
+	ngx_http_variable_t * var = ngx_http_add_variable(cf, name, NGX_HTTP_VAR_NOCACHEABLE);
+	
+	if(var == NULL){
+		return NGX_ERROR;
+	}
+		
+	var->get_handler = ngx_http_auth_spnego_get_handler;
+	var->data = 0;
+	
+	return NGX_OK;
+}
+
+static ngx_int_t ngx_http_auth_spnego_init_shm_zone(ngx_shm_zone_t * shm_zone, void * data){
+	if (data) {
+		shm_zone->data = data;
+        return NGX_OK;
+	}
+	
+	shm_zone->data = shm_zone->shm.addr;
+	return NGX_OK;
+}
+
+static ngx_int_t ngx_http_auth_spnego_create_shm_zone(ngx_conf_t * cf){
+	ngx_str_t name = ngx_string(SHM_ZONE_NAME);
+
+	shm_zone = ngx_shared_memory_add(cf, &name, 65536, &ngx_http_auth_spnego_module);
+	if (shm_zone == NULL) {
+		return NGX_ERROR;
+	}
+		
+	shm_zone->init = ngx_http_auth_spnego_init_shm_zone;
+	
+	return NGX_OK;
 }
 
     static ngx_int_t
@@ -314,7 +506,16 @@ ngx_http_auth_spnego_init(
     }
 
     *h = ngx_http_auth_spnego_handler;
+	
+	if(ngx_http_auth_spnego_create_shm_zone(cf) != NGX_OK){
+		return NGX_ERROR;			
+	}
 
+	ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
+	if(ngx_http_auth_spnego_add_variable(cf, &var_name) != NGX_OK){
+		return NGX_ERROR;
+	}
+	
     return NGX_OK;
 }
 
@@ -410,51 +611,45 @@ ngx_http_auth_spnego_headers(
     return NGX_OK;
 }
 
-    static bool
+	static bool
 ngx_spnego_authorized_principal(
         ngx_http_request_t * r,
         ngx_str_t *princ,
         ngx_http_auth_spnego_loc_conf_t *alcf)
 {
-    if (NGX_CONF_UNSET_PTR == alcf->auth_princs) {
+    if (NGX_CONF_UNSET_PTR == alcf->auth_princs 
+#if (NGX_PCRE)	
+	&& NGX_CONF_UNSET_PTR == alcf->auth_princs_regex
+#endif
+	) {
         return true;
     }
 
-    spnego_debug1("Testing against %d auth princs", alcf->auth_princs->nelts);
+	if(NGX_CONF_UNSET_PTR != alcf->auth_princs){
+		spnego_debug1("Testing against %d auth princs", alcf->auth_princs->nelts);
 
-    ngx_str_t *auth_princs = alcf->auth_princs->elts;  
-    for(size_t i = 0; i < alcf->auth_princs->nelts; i++) {
-#if (NGX_PCRE)
-        ngx_regex_compile_t rc;
-        u_char errstr[NGX_MAX_CONF_ERRSTR];
-
-	ngx_memzero(&rc, sizeof(ngx_regex_compile_t));
-
-        rc.pattern = auth_princs[i];
-	rc.pool = r->pool;
-	rc.err.len = NGX_MAX_CONF_ERRSTR;
-	rc.err.data = errstr;
-        
-        if(ngx_regex_compile(&rc) != NGX_OK) {
-            spnego_debug1("Failed to compile regex %s", auth_princs[i].data);
-	    continue;
+		ngx_str_t *auth_princs = alcf->auth_princs->elts;  
+		for(size_t i = 0; i < alcf->auth_princs->nelts; i++) {
+			if(auth_princs[i].len != princ->len) {
+				continue;
+			}
+			if(ngx_strncmp(auth_princs[i].data, princ->data, princ->len) == 0) {
+				spnego_debug2("Authorized user %.*s", princ->len, princ->data);
+				return true;
+			}
+		}
 	}
+#if (NGX_PCRE)	
+	if(NGX_CONF_UNSET_PTR != alcf->auth_princs_regex){				
+		spnego_debug1("Testing against %d auth princs regex", alcf->auth_princs_regex->nelts);
+	
+		if(ngx_regex_exec_array(alcf->auth_princs_regex, princ, r->connection->log) == NGX_OK){
+			return true;
+		}
+	}
+#endif	
 
-        if(ngx_regex_exec(rc.regex, princ, NULL, 0) == NGX_OK){
-            spnego_debug2("Authorized user %.*s", princ->len, princ->data);
-	    return true;
-        }
-#else
-        if(auth_princs[i].len != princ->len) {
-            continue;
-        }
-        if(ngx_strncmp(auth_princs[i].data, princ->data, princ->len) == 0) {
-            spnego_debug2("Authorized user %.*s", princ->len, princ->data);
-            return true;
-        }
-#endif
-    }
-    return false;
+    return false;	
 }
 
     ngx_int_t
@@ -512,6 +707,168 @@ ngx_http_auth_spnego_token(
     spnego_debug2("Token decoded: %*s", token.len, token.data);
 
     return NGX_OK;
+}
+
+static krb5_error_code ngx_http_auth_spnego_store_krb5_creds(ngx_http_request_t * r,krb5_context kcontext, krb5_principal principal, krb5_ccache ccache, krb5_creds creds){
+	krb5_error_code kerr = 0;
+		
+	if((kerr = krb5_cc_initialize(kcontext, ccache, principal))){
+		spnego_log_error("Kerberos error: Cannot initialize ccache");
+		spnego_log_krb5_error(kcontext, kerr);
+		return kerr;
+	}
+	
+	if((kerr = krb5_cc_store_cred(kcontext, ccache, &creds))){
+		spnego_log_error("Kerberos error: Cannot store credentials");
+		spnego_log_krb5_error(kcontext, kerr);
+		return kerr;
+	}
+	
+	return kerr;
+}
+
+static krb5_error_code ngx_http_auth_spnego_store_gss_creds(ngx_http_request_t * r, krb5_context kcontext, krb5_principal principal, krb5_ccache ccache, gss_cred_id_t creds){
+    OM_uint32 major_status, minor_status;
+	krb5_error_code kerr = 0;
+	
+	if((kerr = krb5_cc_initialize(kcontext, ccache, principal))){
+		spnego_log_error("Kerberos error: Cannot initialize ccache");
+		spnego_log_krb5_error(kcontext, kerr);
+		return kerr;
+	}
+	
+	major_status = gss_krb5_copy_ccache(&minor_status, creds, ccache);
+    if(GSS_ERROR(major_status)){
+		const char * gss_error = get_gss_error(r->pool, minor_status, "ngx_http_auth_spnego_store_gss_creds() failed");
+		spnego_log_error("%s", gss_error);
+		spnego_debug1("%s", gss_error);
+		return KRB5_CC_WRITE;
+	}
+
+	return kerr;
+}
+
+static void ngx_http_auth_spnego_krb5_destroy_ccache(void * data){
+	krb5_context kcontext;
+	krb5_ccache ccache;
+	krb5_error_code kerr = 0;
+	
+	char * ccname = (char *) data;
+	
+	if((kerr = krb5_init_context(&kcontext))){
+		goto done;
+	}
+
+	if((kerr = krb5_cc_resolve(kcontext, ccname, &ccache))){
+		goto done;
+	}
+	
+	krb5_cc_destroy(kcontext, ccache);
+done:
+	if(kcontext) krb5_free_context(kcontext);
+}
+
+static char * ngx_http_auth_spnego_replace(ngx_http_request_t * r, char * str, char find, char replace){
+	char * result = (char *) ngx_palloc(r->pool, ngx_strlen(str) + 1);
+	ngx_memcpy(result, str, ngx_strlen(str) + 1);
+	
+	char * index = NULL;
+    while ((index = ngx_strchr(result,find)) != NULL){
+        *index = replace;
+    }
+    return result;
+}
+
+static ngx_int_t ngx_http_auth_spnego_store_delegated_creds(ngx_http_request_t * r, ngx_str_t * principal_name, creds_info delegated_creds) {
+    krb5_context kcontext;
+    krb5_principal principal = NULL;
+    krb5_ccache ccache = NULL;
+	krb5_error_code kerr = 0;	
+	char * ccname = NULL;
+	char * escaped = NULL;
+									
+	if(!delegated_creds.data){
+		spnego_log_error("ngx_http_auth_spnego_store_delegated_creds() NULL credentials");
+		spnego_debug0("ngx_http_auth_spnego_store_delegated_creds() NULL credentials");
+		goto done;
+	}
+	
+	if((kerr = krb5_init_context(&kcontext))){
+		spnego_log_error("Kerberos error: Cannot initialize kerberos context");
+		spnego_log_krb5_error(kcontext, kerr);
+		goto done;
+	}
+	
+	if((kerr = krb5_parse_name(kcontext, (char *) principal_name->data, &principal))){
+		spnego_log_error("Kerberos error: Cannot parse principal %s", principal_name);
+		spnego_log_krb5_error(kcontext, kerr);
+		goto done;
+	}
+	
+	escaped = ngx_http_auth_spnego_replace(r, (char *) principal_name->data, '/', '_');
+		
+	size_t ccname_size = (ngx_strlen("FILE:") + ngx_strlen(P_tmpdir) + ngx_strlen("/") + ngx_strlen(escaped)) + 1;
+	ccname = (char *) ngx_pcalloc(r->pool, ccname_size);
+	
+	ngx_snprintf(
+		(u_char *) ccname, 
+		ccname_size,
+		"FILE:%s/%*s",
+        P_tmpdir,
+        ngx_strlen(escaped),	
+		escaped
+	);
+	
+	if((kerr = krb5_cc_resolve(kcontext, ccname, &ccache))){
+		spnego_log_error("Kerberos error: Cannot resolve ccache %s", ccname);
+		spnego_log_krb5_error(kcontext, kerr);
+		goto done;
+	}
+	
+	switch(delegated_creds.type){
+		case TYPE_GSS_CRED_ID_T:
+			kerr = ngx_http_auth_spnego_store_gss_creds(
+				r,
+				kcontext, 
+				principal, 
+				ccache, 
+				(gss_cred_id_t) delegated_creds.data
+			);
+			break;
+		case TYPE_KRB5_CREDS:
+			kerr = ngx_http_auth_spnego_store_krb5_creds(
+				r,
+				kcontext, 
+				principal, 
+				ccache, 
+				(*(krb5_creds *) delegated_creds.data)
+			);
+			break;
+		default:
+			kerr = KRB5KRB_ERR_GENERIC;
+	}
+	
+	if(kerr) goto done;
+	
+	ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
+	
+	ngx_str_t var_value = ngx_null_string;
+	var_value.data = (u_char *) ccname;
+	var_value.len = ngx_strlen(ccname);
+	
+	ngx_http_auth_spnego_set_variable(r, &var_name, &var_value);
+	
+	ngx_pool_cleanup_t * cln = ngx_pool_cleanup_add(r->pool, 0);
+	cln->handler = ngx_http_auth_spnego_krb5_destroy_ccache;
+	cln->data = ccname;
+done:
+	if(escaped) ngx_pfree(r->pool, escaped);
+	if(ccname) ngx_pfree(r->pool, ccname);
+	if(principal) krb5_free_principal(kcontext, principal);
+	if(ccache) krb5_cc_close(kcontext, ccache);
+	if(kcontext) krb5_free_context(kcontext);
+	
+	return kerr ? NGX_ERROR : NGX_OK;
 }
 
     ngx_int_t
@@ -693,14 +1050,26 @@ ngx_http_auth_spnego_basic(
                 (char *) r->headers_in.passwd.data,
                 NULL, NULL, 0, NULL, gic_options);
 
-    krb5_free_cred_contents(kcontext, &creds);
-
     if (code) {
         spnego_log_error("Kerberos error: Credentials failed");
         spnego_log_krb5_error(kcontext, code);
         spnego_error(NGX_DECLINED);
     }
 
+	if(alcf->delegate_credentials){
+		creds_info delegated_creds = {
+			&creds,
+			TYPE_KRB5_CREDS
+		};
+		
+		ngx_str_t principal_name = ngx_null_string;
+		principal_name.data = (u_char *) name;
+		principal_name.len = ngx_strlen(name);
+		
+        ngx_http_auth_spnego_store_delegated_creds(r, &principal_name, delegated_creds);
+    }
+	
+	krb5_free_cred_contents(kcontext, &creds);
     /* Try to add the system realm to $remote_user if needed. */
     if (alcf->fqun && !ngx_strchr(r->headers_in.user.data, '@')) {
 #ifdef krb5_princ_realm
@@ -727,7 +1096,7 @@ ngx_http_auth_spnego_basic(
             r->headers_in.user.len = new_user.len;
         }
     }
-
+	
     spnego_debug1("Setting $remote_user to %V", &r->headers_in.user);
     if (ngx_http_auth_spnego_set_bogus_authorization(r) != NGX_OK)
         spnego_log_error("Failed to set $remote_user");
@@ -754,7 +1123,6 @@ end:
 
     return ret;
 }
-
 
 /*
  * Because 'remote_user' is assumed to be provided by basic authorization
@@ -832,6 +1200,230 @@ use_keytab(
     return true;
 }
 
+static krb5_error_code ngx_http_auth_spnego_verify_server_credentials(ngx_http_request_t * r, krb5_context kcontext, ngx_str_t * principal_name, krb5_ccache ccache){
+	krb5_creds match_creds;
+	krb5_creds creds;
+    krb5_timestamp now;
+    krb5_error_code kerr = 0;
+	krb5_principal principal = NULL;
+	char * tgs_principal_name = NULL;
+	char * princ_name = NULL;
+	
+	memset (&match_creds, 0, sizeof(match_creds));
+    memset (&creds, 0, sizeof(creds));
+	
+	if((kerr = krb5_cc_get_principal(kcontext, ccache, &principal))){
+		spnego_log_error("Kerberos error: Cannot get principal from ccache");
+		spnego_log_krb5_error(kcontext, kerr);
+		goto done;
+	}
+	
+	if((kerr = krb5_unparse_name(kcontext, principal, &princ_name))){
+		spnego_log_error("Kerberos error: Cannot unparse principal");
+		spnego_log_krb5_error(kcontext, kerr);
+		goto done;
+	}
+	
+	if(ngx_strncmp(principal_name->data, princ_name, ngx_strlen(princ_name)) != 0){
+		spnego_log_error("Kerberos error: Principal name mismatch");
+		spnego_debug0("Kerberos error: Principal name mismatch");
+		kerr = KRB5KRB_ERR_GENERIC;
+		goto done;
+	}
+	
+	size_t tgs_principal_name_size = (ngx_strlen(KRB5_TGS_NAME) + (principal->realm.length * 2) + 2) + 1;
+	tgs_principal_name = (char *) ngx_pcalloc(r->pool, tgs_principal_name_size);
+	ngx_snprintf(
+		(u_char *) tgs_principal_name, 
+		tgs_principal_name_size,
+		"%s/%*s@%*s", 
+		KRB5_TGS_NAME,
+		principal->realm.length,
+		principal->realm.data,
+		principal->realm.length,
+		principal->realm.data
+	);
+	
+	if ((kerr = krb5_parse_name(kcontext, tgs_principal_name, &match_creds.server))){
+		spnego_log_error("Kerberos error: Cannot parse principal: %s", tgs_principal_name);
+		spnego_log_krb5_error(kcontext, kerr);
+		goto done;		
+	}
+	
+    match_creds.client = principal;	
+	
+	if ((kerr = krb5_cc_retrieve_cred(kcontext, ccache, 0, &match_creds, &creds))){
+		spnego_log_error("Kerberos error: Cannot retrieve credentials");
+		spnego_log_krb5_error(kcontext, kerr);
+		goto done;		
+	}
+	
+    if ((kerr = krb5_timeofday(kcontext, &now))) {
+		spnego_log_error("Kerberos error: Could not get current time");
+		spnego_log_krb5_error(kcontext, kerr);		
+		goto done;		
+	}
+	
+    if ((now + RENEWAL_TIME) > creds.times.endtime) {
+		spnego_debug2("Credentials for %s have expired or will expire soon at %d - renewing", princ_name, creds.times.endtime);
+		kerr = KRB5KRB_AP_ERR_TKT_EXPIRED;
+	}else{
+		spnego_debug2("Credentials for %s will expire at %d", princ_name, creds.times.endtime);
+	}
+done:
+    if(principal) krb5_free_principal(kcontext, principal);
+    if(match_creds.server) krb5_free_principal(kcontext, match_creds.server);
+	if(creds.client) krb5_free_cred_contents(kcontext, &creds);
+	
+	return kerr;
+}
+
+static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(ngx_http_request_t * r, ngx_str_t * service_name, ngx_str_t * keytab_path, ngx_str_t * service_ccache) {
+	krb5_context kcontext = NULL;
+    krb5_keytab keytab = NULL;
+    krb5_ccache ccache = NULL;
+    krb5_error_code kerr = 0;
+    krb5_principal principal = NULL;
+	krb5_get_init_creds_opt gicopts;
+    krb5_creds creds;
+		
+	char * principal_name = NULL;
+    char * tgs_principal_name = NULL;
+	char kt_path[1024];
+    char cc_name[1024];
+		
+	memset(&creds, 0, sizeof(creds));
+		
+	if((kerr = krb5_init_context(&kcontext))){
+		spnego_log_error("Kerberos error: Cannot initialize kerberos context");
+		spnego_log_krb5_error(kcontext, kerr);
+		goto done;
+	}
+	
+	if(service_ccache->len && service_ccache->data){
+		ngx_snprintf(
+			(u_char *) cc_name, 
+			sizeof(cc_name), 
+			"FILE:%V%Z", 
+			service_ccache
+		);
+		
+		if((kerr = krb5_cc_resolve(kcontext, cc_name, &ccache))){
+			spnego_log_error("Kerberos error: Cannot resolve ccache %s", cc_name);
+			spnego_log_krb5_error(kcontext, kerr);		
+			goto done;
+		}
+	}else{
+		 if ((kerr = krb5_cc_default(kcontext, &ccache))) {
+			spnego_log_error("Kerberos error: Cannot get default ccache");
+			spnego_log_krb5_error(kcontext, kerr);		
+			goto done;
+		}
+		
+		ngx_snprintf(
+			(u_char *) cc_name, 
+			sizeof(cc_name), 
+			"%s:%s", 
+			krb5_cc_get_type(kcontext, ccache),
+			krb5_cc_get_name(kcontext, ccache)
+		);
+	}
+	
+	if((kerr = ngx_http_auth_spnego_verify_server_credentials(r, kcontext, service_name, ccache))){
+		if (kerr == KRB5_FCC_NOFILE || kerr == KRB5KRB_AP_ERR_TKT_EXPIRED) {
+			if((kerr = krb5_parse_name(kcontext, (char *) service_name->data, &principal))){
+				spnego_log_error("Kerberos error: Cannot parse principal %s", (char *) service_name->data);
+				spnego_log_krb5_error(kcontext, kerr);
+				goto done;
+			}
+			if((kerr = krb5_unparse_name(kcontext, principal, &principal_name))){
+				spnego_log_error("Kerberos error: Cannot unparse principal");
+				spnego_log_krb5_error(kcontext, kerr);
+				goto done;
+			}
+		}else{
+			spnego_log_error("Kerberos error: Error verifying server credentials");
+			spnego_log_krb5_error(kcontext, kerr);
+			goto done;
+		}
+	}else{
+		spnego_debug0("Server credentials valid");
+		goto done;
+	}
+
+	ngx_slab_pool_t * shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
+	
+	ngx_shmtx_lock(&shpool->mutex);
+	
+	kerr = ngx_http_auth_spnego_verify_server_credentials(r, kcontext, service_name, ccache);
+	if((kerr != KRB5_FCC_NOFILE && kerr != KRB5KRB_AP_ERR_TKT_EXPIRED)) goto unlock;
+
+	ngx_snprintf((u_char *) kt_path, sizeof(kt_path), "FILE:%V%Z", keytab_path);
+			
+	if((kerr = krb5_kt_resolve(kcontext, kt_path, &keytab))){
+		spnego_log_error("Kerberos error: Cannot resolve keytab %s", kt_path);
+		spnego_log_krb5_error(kcontext, kerr);			
+		goto unlock;
+	}
+			
+	spnego_debug1("Obtaining new credentials for %s", principal_name);
+			
+	krb5_get_init_creds_opt_init(&gicopts);
+	krb5_get_init_creds_opt_set_forwardable(&gicopts, 1);
+			
+	size_t tgs_principal_name_size = (ngx_strlen(KRB5_TGS_NAME) + (principal->realm.length * 2) + 2) + 1;
+	tgs_principal_name = (char *) ngx_pcalloc(r->pool, tgs_principal_name_size);
+						
+	ngx_snprintf(
+		(u_char *) tgs_principal_name, 
+		tgs_principal_name_size,
+		"%s/%*s@%*s", 
+		KRB5_TGS_NAME,
+		principal->realm.length,
+		principal->realm.data,
+		principal->realm.length,
+		principal->realm.data
+	);
+				
+	kerr = krb5_get_init_creds_keytab(
+		kcontext, 
+		&creds, 
+		principal, 
+		keytab,
+		0, 
+		tgs_principal_name, 
+		&gicopts
+	);
+	if(kerr){
+		spnego_log_error("Kerberos error: Cannot obtain credentials for principal %s", principal_name);
+		spnego_log_krb5_error(kcontext, kerr);				
+		goto unlock;
+	}
+
+	if((kerr = ngx_http_auth_spnego_store_krb5_creds(r, kcontext, principal, ccache, creds))){
+		spnego_debug0("ngx_http_auth_spnego_store_krb5_creds() failed");
+		goto unlock;
+	}
+		
+unlock:
+	ngx_shmtx_unlock(&shpool->mutex);
+done:
+    if (!kerr) {
+		spnego_debug0("Successfully obtained server credentials");
+		setenv("KRB5CCNAME", cc_name, 1);
+	} else {
+		spnego_debug0("Failed to obtain server credentials");
+	}
+	
+    if (tgs_principal_name) ngx_pfree(r->pool, tgs_principal_name);
+	if (creds.client) krb5_free_cred_contents(kcontext, &creds);
+	if (keytab) krb5_kt_close(kcontext, keytab);
+    if (ccache) krb5_cc_close(kcontext, ccache);
+    if (kcontext) krb5_free_context(kcontext);
+		
+    return kerr ? NGX_ERROR : NGX_OK;
+}
+
     ngx_int_t
 ngx_http_auth_spnego_auth_user_gss(
         ngx_http_request_t * r,
@@ -844,7 +1436,10 @@ ngx_http_auth_spnego_auth_user_gss(
     OM_uint32 major_status, minor_status, minor_status2;
     gss_buffer_desc service = GSS_C_EMPTY_BUFFER;
     gss_name_t my_gss_name = GSS_C_NO_NAME;
+	
     gss_cred_id_t my_gss_creds = GSS_C_NO_CREDENTIAL;
+    gss_cred_id_t delegated_creds = GSS_C_NO_CREDENTIAL;
+
     gss_buffer_desc input_token = GSS_C_EMPTY_BUFFER;
     gss_ctx_id_t gss_context = GSS_C_NO_CONTEXT;
     gss_name_t client_name = GSS_C_NO_NAME;
@@ -891,18 +1486,31 @@ ngx_http_auth_spnego_auth_user_gss(
                     (u_char *) service.value);
         }
         spnego_debug1("my_gss_name %s", human_readable_gss_name.value);
-
+		
+		if(alcf->constrained_delegation){
+			ngx_str_t service_name = ngx_null_string;
+			service_name.data = (u_char *) service.value;
+			service_name.len = service.length;
+			
+			ngx_http_auth_spnego_obtain_server_credentials(
+				r, 
+				&service_name,
+				&alcf->keytab,
+				&alcf->service_ccache
+			);
+		}
+		
         /* Obtain credentials */
         major_status = gss_acquire_cred(&minor_status, my_gss_name,
-                GSS_C_INDEFINITE, GSS_C_NO_OID_SET, GSS_C_ACCEPT, &my_gss_creds,
+                GSS_C_INDEFINITE, GSS_C_NO_OID_SET, (alcf->constrained_delegation ? GSS_C_BOTH : GSS_C_ACCEPT), &my_gss_creds,
                 NULL, NULL);
+		
         if (GSS_ERROR(major_status)) {
             spnego_log_error("%s Used service principal: %s", get_gss_error(
                         r->pool, minor_status, "gss_acquire_cred() failed"),
                     (u_char *) service.value);
             spnego_error(NGX_ERROR);
         }
-
     }
 
     input_token.length = ctx->token.len;
@@ -910,7 +1518,7 @@ ngx_http_auth_spnego_auth_user_gss(
 
     major_status = gss_accept_sec_context(&minor_status, &gss_context,
             my_gss_creds, &input_token, GSS_C_NO_CHANNEL_BINDINGS, &client_name,
-            NULL, &output_token, NULL, NULL, NULL);
+            NULL, &output_token, NULL, NULL, &delegated_creds);
     if (GSS_ERROR(major_status)) {
         spnego_debug1("%s", get_gss_error(
                     r->pool, minor_status, "gss_accept_sec_context() failed"));
@@ -990,7 +1598,20 @@ ngx_http_auth_spnego_auth_user_gss(
         }
         spnego_debug1("user is %V", &r->headers_in.user);
     }
-
+    	
+    if(alcf->delegate_credentials){
+		creds_info creds = {
+			delegated_creds,
+			TYPE_GSS_CRED_ID_T
+		};
+		
+		ngx_str_t principal_name = ngx_null_string;
+		principal_name.data = (u_char *) output_token.value;
+		principal_name.len = output_token.length;
+		
+        ngx_http_auth_spnego_store_delegated_creds(r, &principal_name, creds);
+    }
+	
     gss_release_buffer(&minor_status, &output_token);
 
     ret = NGX_OK;
@@ -1012,6 +1633,9 @@ end:
 
     if (my_gss_creds != GSS_C_NO_CREDENTIAL)
         gss_release_cred(&minor_status, &my_gss_creds);
+
+    if (delegated_creds != GSS_C_NO_CREDENTIAL)
+        gss_release_cred(&minor_status, &delegated_creds);
 
     return ret;
 }
@@ -1114,7 +1738,7 @@ ngx_http_auth_spnego_handler(
             spnego_debug0("User not authorized");
             return (ctx->ret = NGX_HTTP_FORBIDDEN);
         }
-
+		
         spnego_debug0("GSSAPI auth succeeded");
     }
 

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -36,8 +36,6 @@
 #include <gssapi/gssapi_krb5.h>
 #include <krb5.h>
 
-#include <time.h>
-
 #define CCACHE_VARIABLE_NAME "krb5_cc_name"
 #define SHM_ZONE_NAME "shm_zone"
 #define RENEWAL_TIME 60
@@ -109,13 +107,13 @@ get_gss_error(
 static ngx_shm_zone_t * shm_zone;
 
 typedef enum {
-	TYPE_KRB5_CREDS,
-	TYPE_GSS_CRED_ID_T
+    TYPE_KRB5_CREDS,
+    TYPE_GSS_CRED_ID_T
 } creds_type;
 
 typedef struct {
-	void * data;
-	creds_type type;
+    void * data;
+    creds_type type;
 } creds_info;
 
 /* per request/connection */
@@ -130,14 +128,14 @@ typedef struct {
     ngx_flag_t protect;
     ngx_str_t realm;
     ngx_str_t keytab;
-	ngx_str_t service_ccache;
+    ngx_str_t service_ccache;
     ngx_str_t srvcname;
     ngx_flag_t fqun;
     ngx_flag_t force_realm;
     ngx_flag_t allow_basic;
     ngx_array_t * auth_princs;
 #if (NGX_PCRE)
-	ngx_array_t * auth_princs_regex;
+    ngx_array_t * auth_princs_regex;
 #endif
     ngx_flag_t map_to_local;
     ngx_flag_t delegate_credentials;
@@ -279,50 +277,50 @@ ngx_module_t ngx_http_auth_spnego_module = {
 
 #if (NGX_PCRE)
 static char * ngx_conf_set_regex_array_slot(ngx_conf_t * cf, ngx_command_t * cmd, void * conf){
-	char * p = conf;
-	u_char errstr[NGX_MAX_CONF_ERRSTR];
-	ngx_str_t * value;
-	ngx_regex_elt_t * re;
-	ngx_regex_compile_t rc;
-	ngx_array_t ** a;
-	ngx_conf_post_t * post;
+    char * p = conf;
+    u_char errstr[NGX_MAX_CONF_ERRSTR];
+    ngx_str_t * value;
+    ngx_regex_elt_t * re;
+    ngx_regex_compile_t rc;
+    ngx_array_t ** a;
+    ngx_conf_post_t * post;
 	
-	a = (ngx_array_t **) (p + cmd->offset);
+    a = (ngx_array_t **) (p + cmd->offset);
 	
-	if (*a == NGX_CONF_UNSET_PTR) {
-		*a = ngx_array_create(cf->pool, 4, sizeof(ngx_regex_elt_t));
-		if (*a == NULL) {
-			return NGX_CONF_ERROR;
-		}
-	}
+    if (*a == NGX_CONF_UNSET_PTR) {
+        *a = ngx_array_create(cf->pool, 4, sizeof(ngx_regex_elt_t));
+        if (*a == NULL) {
+	    return NGX_CONF_ERROR;
+        }
+    }
 
-	re = ngx_array_push(*a);
-	if (re == NULL) {
-		return NGX_CONF_ERROR;
-	}
+    re = ngx_array_push(*a);
+    if (re == NULL) {
+        return NGX_CONF_ERROR;
+    }
 	
-	value = cf->args->elts;
+    value = cf->args->elts;
 	
-	ngx_memzero(&rc, sizeof(ngx_regex_compile_t));
+    ngx_memzero(&rc, sizeof(ngx_regex_compile_t));
 	
-	rc.pattern = value[1];
-	rc.pool = cf->pool;
-	rc.err.len = NGX_MAX_CONF_ERRSTR;
-	rc.err.data = errstr;
+    rc.pattern = value[1];
+    rc.pool = cf->pool;
+    rc.err.len = NGX_MAX_CONF_ERRSTR;
+    rc.err.data = errstr;
 	
-	if(ngx_regex_compile(&rc) != NGX_OK) {
-		return NGX_CONF_ERROR;
-	}
+    if(ngx_regex_compile(&rc) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
 	
-	re->regex = rc.regex;
-	re->name = value[1].data;
+    re->regex = rc.regex;
+    re->name = value[1].data;
 	
-	if (cmd->post) {
-		post = cmd->post;
-		return post->post_handler(cf, post, re);
-	}
+    if (cmd->post) {
+        post = cmd->post;
+        return post->post_handler(cf, post, re);
+    }
 	
-	return NGX_CONF_OK;
+    return NGX_CONF_OK;
 }
 #endif
 
@@ -342,7 +340,7 @@ ngx_http_auth_spnego_create_loc_conf(
     conf->force_realm = NGX_CONF_UNSET;
     conf->allow_basic = NGX_CONF_UNSET;
     conf->auth_princs = NGX_CONF_UNSET_PTR;
-	conf->auth_princs_regex = NGX_CONF_UNSET_PTR;
+    conf->auth_princs_regex = NGX_CONF_UNSET_PTR;
     conf->map_to_local = NGX_CONF_UNSET;
     conf->delegate_credentials = NGX_CONF_UNSET;
     conf->constrained_delegation = NGX_CONF_UNSET;
@@ -365,7 +363,7 @@ ngx_http_auth_spnego_merge_loc_conf(
     ngx_conf_merge_str_value(conf->realm, prev->realm, "");
     ngx_conf_merge_str_value(conf->keytab, prev->keytab, "/etc/krb5.keytab");
 			
-	ngx_conf_merge_str_value(conf->service_ccache, prev->service_ccache, "");
+    ngx_conf_merge_str_value(conf->service_ccache, prev->service_ccache, "");
 			
     ngx_conf_merge_str_value(conf->srvcname, prev->srvcname, "");
 
@@ -389,7 +387,7 @@ ngx_http_auth_spnego_merge_loc_conf(
     ngx_conf_log_error(NGX_LOG_INFO, cf, 0,
             "auth_spnego: keytab@0x%p = %s", conf->keytab.data,
             conf->keytab.data);
-	ngx_conf_log_error(NGX_LOG_INFO, cf, 0,
+    ngx_conf_log_error(NGX_LOG_INFO, cf, 0,
             "auth_spnego: service_ccache@0x%p = %s", conf->service_ccache.data,
             conf->service_ccache.data);
     ngx_conf_log_error(NGX_LOG_INFO, cf, 0,
@@ -412,14 +410,14 @@ ngx_http_auth_spnego_merge_loc_conf(
     }
 	
 #if (NGX_PCRE)	
-	if (NGX_CONF_UNSET_PTR != conf->auth_princs_regex){
-		size_t ii = 0;
+    if (NGX_CONF_UNSET_PTR != conf->auth_princs_regex){
+        size_t ii = 0;
         ngx_regex_elt_t * auth_princs_regex = conf->auth_princs_regex->elts;
         for (; ii < conf->auth_princs_regex->nelts; ++ii) {
             ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0,
                     "auth_spnego: auth_princs_regex = %.*s", ngx_strlen(auth_princs_regex[ii].name), auth_princs_regex[ii].name);
         }
-	}
+    }
 #endif
 	
     ngx_conf_log_error(NGX_LOG_INFO, cf, 0, "auth_spnego: map_to_local = %i",
@@ -438,57 +436,57 @@ ngx_http_auth_spnego_merge_loc_conf(
 static ngx_int_t ngx_http_auth_spnego_get_handler(ngx_http_request_t * r, ngx_http_variable_value_t * v, uintptr_t data){ return NGX_OK; }
 
 static ngx_int_t ngx_http_auth_spnego_set_variable(ngx_http_request_t * r, ngx_str_t * name, ngx_str_t * value){
-	u_char * lowercase = ngx_palloc(r->pool, name->len);
+    u_char * lowercase = ngx_palloc(r->pool, name->len);
 		
-	ngx_uint_t key = ngx_hash_strlow(lowercase, name->data, name->len);	
-	ngx_pfree(r->pool, lowercase);
+    ngx_uint_t key = ngx_hash_strlow(lowercase, name->data, name->len);	
+    ngx_pfree(r->pool, lowercase);
 	
-	ngx_http_variable_value_t * v = ngx_http_get_variable(r, name, key);
+    ngx_http_variable_value_t * v = ngx_http_get_variable(r, name, key);
 		
-	if(v == NULL){
-		return NGX_ERROR;
-	}
+    if(v == NULL){
+        return NGX_ERROR;
+    }
 	
-	v->len = value->len;
-	v->data = value->data;
+    v->len = value->len;
+    v->data = value->data;
 		
-	return NGX_OK;
+    return NGX_OK;
 }
 
 static ngx_int_t ngx_http_auth_spnego_add_variable(ngx_conf_t * cf, ngx_str_t * name){	
-	ngx_http_variable_t * var = ngx_http_add_variable(cf, name, NGX_HTTP_VAR_NOCACHEABLE);
+    ngx_http_variable_t * var = ngx_http_add_variable(cf, name, NGX_HTTP_VAR_NOCACHEABLE);
 	
-	if(var == NULL){
-		return NGX_ERROR;
-	}
+    if(var == NULL){
+        return NGX_ERROR;
+    }
 		
-	var->get_handler = ngx_http_auth_spnego_get_handler;
-	var->data = 0;
+    var->get_handler = ngx_http_auth_spnego_get_handler;
+    var->data = 0;
 	
-	return NGX_OK;
+    return NGX_OK;
 }
 
 static ngx_int_t ngx_http_auth_spnego_init_shm_zone(ngx_shm_zone_t * shm_zone, void * data){
-	if (data) {
-		shm_zone->data = data;
+    if (data) {
+        shm_zone->data = data;
         return NGX_OK;
-	}
+    }
 	
-	shm_zone->data = shm_zone->shm.addr;
-	return NGX_OK;
+    shm_zone->data = shm_zone->shm.addr;
+    return NGX_OK;
 }
 
 static ngx_int_t ngx_http_auth_spnego_create_shm_zone(ngx_conf_t * cf){
-	ngx_str_t name = ngx_string(SHM_ZONE_NAME);
+    ngx_str_t name = ngx_string(SHM_ZONE_NAME);
 
-	shm_zone = ngx_shared_memory_add(cf, &name, 65536, &ngx_http_auth_spnego_module);
-	if (shm_zone == NULL) {
-		return NGX_ERROR;
-	}
+    shm_zone = ngx_shared_memory_add(cf, &name, 65536, &ngx_http_auth_spnego_module);
+    if (shm_zone == NULL) {
+        return NGX_ERROR;
+    }
 		
-	shm_zone->init = ngx_http_auth_spnego_init_shm_zone;
+    shm_zone->init = ngx_http_auth_spnego_init_shm_zone;
 	
-	return NGX_OK;
+    return NGX_OK;
 }
 
     static ngx_int_t
@@ -507,14 +505,14 @@ ngx_http_auth_spnego_init(
 
     *h = ngx_http_auth_spnego_handler;
 	
-	if(ngx_http_auth_spnego_create_shm_zone(cf) != NGX_OK){
-		return NGX_ERROR;			
-	}
+    if(ngx_http_auth_spnego_create_shm_zone(cf) != NGX_OK){
+        return NGX_ERROR;			
+    }
 
-	ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
-	if(ngx_http_auth_spnego_add_variable(cf, &var_name) != NGX_OK){
-		return NGX_ERROR;
-	}
+    ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
+    if(ngx_http_auth_spnego_add_variable(cf, &var_name) != NGX_OK){
+        return NGX_ERROR;
+    }
 	
     return NGX_OK;
 }
@@ -621,32 +619,32 @@ ngx_spnego_authorized_principal(
 #if (NGX_PCRE)	
 	&& NGX_CONF_UNSET_PTR == alcf->auth_princs_regex
 #endif
-	) {
+    ) {
         return true;
     }
 
-	if(NGX_CONF_UNSET_PTR != alcf->auth_princs){
-		spnego_debug1("Testing against %d auth princs", alcf->auth_princs->nelts);
+    if(NGX_CONF_UNSET_PTR != alcf->auth_princs){
+        spnego_debug1("Testing against %d auth princs", alcf->auth_princs->nelts);
 
-		ngx_str_t *auth_princs = alcf->auth_princs->elts;  
-		for(size_t i = 0; i < alcf->auth_princs->nelts; i++) {
-			if(auth_princs[i].len != princ->len) {
-				continue;
-			}
-			if(ngx_strncmp(auth_princs[i].data, princ->data, princ->len) == 0) {
-				spnego_debug2("Authorized user %.*s", princ->len, princ->data);
-				return true;
-			}
-		}
-	}
+        ngx_str_t *auth_princs = alcf->auth_princs->elts;  
+        for(size_t i = 0; i < alcf->auth_princs->nelts; i++) {
+	    if(auth_princs[i].len != princ->len) {
+                continue;
+            }
+            if(ngx_strncmp(auth_princs[i].data, princ->data, princ->len) == 0) {
+                spnego_debug2("Authorized user %.*s", princ->len, princ->data);
+                return true;
+            }
+        }
+    }
 #if (NGX_PCRE)	
-	if(NGX_CONF_UNSET_PTR != alcf->auth_princs_regex){				
-		spnego_debug1("Testing against %d auth princs regex", alcf->auth_princs_regex->nelts);
+    if(NGX_CONF_UNSET_PTR != alcf->auth_princs_regex){				
+        spnego_debug1("Testing against %d auth princs regex", alcf->auth_princs_regex->nelts);
 	
-		if(ngx_regex_exec_array(alcf->auth_princs_regex, princ, r->connection->log) == NGX_OK){
-			return true;
-		}
-	}
+        if(ngx_regex_exec_array(alcf->auth_princs_regex, princ, r->connection->log) == NGX_OK){
+            return true;
+        }
+    }
 #endif	
 
     return false;	
@@ -710,69 +708,69 @@ ngx_http_auth_spnego_token(
 }
 
 static krb5_error_code ngx_http_auth_spnego_store_krb5_creds(ngx_http_request_t * r,krb5_context kcontext, krb5_principal principal, krb5_ccache ccache, krb5_creds creds){
-	krb5_error_code kerr = 0;
+    krb5_error_code kerr = 0;
 		
-	if((kerr = krb5_cc_initialize(kcontext, ccache, principal))){
-		spnego_log_error("Kerberos error: Cannot initialize ccache");
-		spnego_log_krb5_error(kcontext, kerr);
-		return kerr;
-	}
+    if((kerr = krb5_cc_initialize(kcontext, ccache, principal))){
+        spnego_log_error("Kerberos error: Cannot initialize ccache");
+        spnego_log_krb5_error(kcontext, kerr);
+        return kerr;
+    }
 	
-	if((kerr = krb5_cc_store_cred(kcontext, ccache, &creds))){
-		spnego_log_error("Kerberos error: Cannot store credentials");
-		spnego_log_krb5_error(kcontext, kerr);
-		return kerr;
-	}
+    if((kerr = krb5_cc_store_cred(kcontext, ccache, &creds))){
+        spnego_log_error("Kerberos error: Cannot store credentials");
+        spnego_log_krb5_error(kcontext, kerr);
+        return kerr;
+    }
 	
-	return kerr;
+    return kerr;
 }
 
 static krb5_error_code ngx_http_auth_spnego_store_gss_creds(ngx_http_request_t * r, krb5_context kcontext, krb5_principal principal, krb5_ccache ccache, gss_cred_id_t creds){
     OM_uint32 major_status, minor_status;
-	krb5_error_code kerr = 0;
+    krb5_error_code kerr = 0;
 	
-	if((kerr = krb5_cc_initialize(kcontext, ccache, principal))){
-		spnego_log_error("Kerberos error: Cannot initialize ccache");
-		spnego_log_krb5_error(kcontext, kerr);
-		return kerr;
-	}
+    if((kerr = krb5_cc_initialize(kcontext, ccache, principal))){
+        spnego_log_error("Kerberos error: Cannot initialize ccache");
+        spnego_log_krb5_error(kcontext, kerr);
+        return kerr;
+    }
 	
-	major_status = gss_krb5_copy_ccache(&minor_status, creds, ccache);
+    major_status = gss_krb5_copy_ccache(&minor_status, creds, ccache);
     if(GSS_ERROR(major_status)){
-		const char * gss_error = get_gss_error(r->pool, minor_status, "ngx_http_auth_spnego_store_gss_creds() failed");
-		spnego_log_error("%s", gss_error);
-		spnego_debug1("%s", gss_error);
-		return KRB5_CC_WRITE;
-	}
+        const char * gss_error = get_gss_error(r->pool, minor_status, "ngx_http_auth_spnego_store_gss_creds() failed");
+        spnego_log_error("%s", gss_error);
+        spnego_debug1("%s", gss_error);
+        return KRB5_CC_WRITE;
+    }
 
-	return kerr;
+    return kerr;
 }
 
 static void ngx_http_auth_spnego_krb5_destroy_ccache(void * data){
-	krb5_context kcontext;
-	krb5_ccache ccache;
-	krb5_error_code kerr = 0;
+    krb5_context kcontext;
+    krb5_ccache ccache;
+    krb5_error_code kerr = 0;
 	
-	char * ccname = (char *) data;
+    char * ccname = (char *) data;
 	
-	if((kerr = krb5_init_context(&kcontext))){
-		goto done;
-	}
+    if((kerr = krb5_init_context(&kcontext))){
+        goto done;
+    }
 
-	if((kerr = krb5_cc_resolve(kcontext, ccname, &ccache))){
-		goto done;
-	}
+    if((kerr = krb5_cc_resolve(kcontext, ccname, &ccache))){
+        goto done;
+    }
 	
-	krb5_cc_destroy(kcontext, ccache);
+    krb5_cc_destroy(kcontext, ccache);
 done:
-	if(kcontext) krb5_free_context(kcontext);
+    if(kcontext) krb5_free_context(kcontext);
 }
 
 static char * ngx_http_auth_spnego_replace(ngx_http_request_t * r, char * str, char find, char replace){
-	char * result = (char *) ngx_palloc(r->pool, ngx_strlen(str) + 1);
-	ngx_memcpy(result, str, ngx_strlen(str) + 1);
+    char * result = (char *) ngx_palloc(r->pool, ngx_strlen(str) + 1);
+    ngx_memcpy(result, str, ngx_strlen(str) + 1);
 	
-	char * index = NULL;
+    char * index = NULL;
     while ((index = ngx_strchr(result,find)) != NULL){
         *index = replace;
     }
@@ -783,92 +781,92 @@ static ngx_int_t ngx_http_auth_spnego_store_delegated_creds(ngx_http_request_t *
     krb5_context kcontext;
     krb5_principal principal = NULL;
     krb5_ccache ccache = NULL;
-	krb5_error_code kerr = 0;	
-	char * ccname = NULL;
-	char * escaped = NULL;
+    krb5_error_code kerr = 0;	
+    char * ccname = NULL;
+    char * escaped = NULL;
 									
-	if(!delegated_creds.data){
-		spnego_log_error("ngx_http_auth_spnego_store_delegated_creds() NULL credentials");
-		spnego_debug0("ngx_http_auth_spnego_store_delegated_creds() NULL credentials");
-		goto done;
-	}
+    if(!delegated_creds.data){
+        spnego_log_error("ngx_http_auth_spnego_store_delegated_creds() NULL credentials");
+        spnego_debug0("ngx_http_auth_spnego_store_delegated_creds() NULL credentials");
+        goto done;
+    }
 	
-	if((kerr = krb5_init_context(&kcontext))){
-		spnego_log_error("Kerberos error: Cannot initialize kerberos context");
-		spnego_log_krb5_error(kcontext, kerr);
-		goto done;
-	}
+    if((kerr = krb5_init_context(&kcontext))){
+        spnego_log_error("Kerberos error: Cannot initialize kerberos context");
+        spnego_log_krb5_error(kcontext, kerr);
+        goto done;
+    }
 	
-	if((kerr = krb5_parse_name(kcontext, (char *) principal_name->data, &principal))){
-		spnego_log_error("Kerberos error: Cannot parse principal %s", principal_name);
-		spnego_log_krb5_error(kcontext, kerr);
-		goto done;
-	}
+    if((kerr = krb5_parse_name(kcontext, (char *) principal_name->data, &principal))){
+        spnego_log_error("Kerberos error: Cannot parse principal %s", principal_name);
+        spnego_log_krb5_error(kcontext, kerr);
+        goto done;
+    }
 	
-	escaped = ngx_http_auth_spnego_replace(r, (char *) principal_name->data, '/', '_');
+    escaped = ngx_http_auth_spnego_replace(r, (char *) principal_name->data, '/', '_');
 		
-	size_t ccname_size = (ngx_strlen("FILE:") + ngx_strlen(P_tmpdir) + ngx_strlen("/") + ngx_strlen(escaped)) + 1;
-	ccname = (char *) ngx_pcalloc(r->pool, ccname_size);
+    size_t ccname_size = (ngx_strlen("FILE:") + ngx_strlen(P_tmpdir) + ngx_strlen("/") + ngx_strlen(escaped)) + 1;
+    ccname = (char *) ngx_pcalloc(r->pool, ccname_size);
 	
-	ngx_snprintf(
-		(u_char *) ccname, 
-		ccname_size,
-		"FILE:%s/%*s",
+    ngx_snprintf(
+        (u_char *) ccname, 
+        ccname_size,
+        "FILE:%s/%*s",
         P_tmpdir,
         ngx_strlen(escaped),	
-		escaped
-	);
+        escaped
+    );
 	
-	if((kerr = krb5_cc_resolve(kcontext, ccname, &ccache))){
-		spnego_log_error("Kerberos error: Cannot resolve ccache %s", ccname);
-		spnego_log_krb5_error(kcontext, kerr);
-		goto done;
-	}
+    if((kerr = krb5_cc_resolve(kcontext, ccname, &ccache))){
+        spnego_log_error("Kerberos error: Cannot resolve ccache %s", ccname);
+        spnego_log_krb5_error(kcontext, kerr);
+        goto done;
+    }
 	
-	switch(delegated_creds.type){
-		case TYPE_GSS_CRED_ID_T:
-			kerr = ngx_http_auth_spnego_store_gss_creds(
-				r,
-				kcontext, 
-				principal, 
-				ccache, 
-				(gss_cred_id_t) delegated_creds.data
-			);
-			break;
-		case TYPE_KRB5_CREDS:
-			kerr = ngx_http_auth_spnego_store_krb5_creds(
-				r,
-				kcontext, 
-				principal, 
-				ccache, 
-				(*(krb5_creds *) delegated_creds.data)
-			);
-			break;
-		default:
-			kerr = KRB5KRB_ERR_GENERIC;
-	}
+    switch(delegated_creds.type){
+        case TYPE_GSS_CRED_ID_T:
+            kerr = ngx_http_auth_spnego_store_gss_creds(
+                r,
+                kcontext, 
+                principal, 
+                ccache, 
+                (gss_cred_id_t) delegated_creds.data
+            );
+            break;
+        case TYPE_KRB5_CREDS:
+            kerr = ngx_http_auth_spnego_store_krb5_creds(
+                r,
+                kcontext, 
+                principal, 
+                ccache, 
+                (*(krb5_creds *) delegated_creds.data)
+            );
+            break;
+        default:
+            kerr = KRB5KRB_ERR_GENERIC;
+    }
 	
-	if(kerr) goto done;
+    if(kerr) goto done;
 	
-	ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
+    ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
 	
-	ngx_str_t var_value = ngx_null_string;
-	var_value.data = (u_char *) ccname;
-	var_value.len = ngx_strlen(ccname);
+    ngx_str_t var_value = ngx_null_string;
+    var_value.data = (u_char *) ccname;
+    var_value.len = ngx_strlen(ccname);
 	
-	ngx_http_auth_spnego_set_variable(r, &var_name, &var_value);
+    ngx_http_auth_spnego_set_variable(r, &var_name, &var_value);
 	
-	ngx_pool_cleanup_t * cln = ngx_pool_cleanup_add(r->pool, 0);
-	cln->handler = ngx_http_auth_spnego_krb5_destroy_ccache;
-	cln->data = ccname;
+    ngx_pool_cleanup_t * cln = ngx_pool_cleanup_add(r->pool, 0);
+    cln->handler = ngx_http_auth_spnego_krb5_destroy_ccache;
+    cln->data = ccname;
 done:
-	if(escaped) ngx_pfree(r->pool, escaped);
-	if(ccname) ngx_pfree(r->pool, ccname);
-	if(principal) krb5_free_principal(kcontext, principal);
-	if(ccache) krb5_cc_close(kcontext, ccache);
-	if(kcontext) krb5_free_context(kcontext);
+    if(escaped) ngx_pfree(r->pool, escaped);
+    if(ccname) ngx_pfree(r->pool, ccname);
+    if(principal) krb5_free_principal(kcontext, principal);
+    if(ccache) krb5_cc_close(kcontext, ccache);
+    if(kcontext) krb5_free_context(kcontext);
 	
-	return kerr ? NGX_ERROR : NGX_OK;
+    return kerr ? NGX_ERROR : NGX_OK;
 }
 
     ngx_int_t
@@ -1056,20 +1054,20 @@ ngx_http_auth_spnego_basic(
         spnego_error(NGX_DECLINED);
     }
 
-	if(alcf->delegate_credentials){
-		creds_info delegated_creds = {
-			&creds,
-			TYPE_KRB5_CREDS
-		};
+    if(alcf->delegate_credentials){
+        creds_info delegated_creds = {
+            &creds,
+            TYPE_KRB5_CREDS
+        };
 		
-		ngx_str_t principal_name = ngx_null_string;
-		principal_name.data = (u_char *) name;
-		principal_name.len = ngx_strlen(name);
+        ngx_str_t principal_name = ngx_null_string;
+        principal_name.data = (u_char *) name;
+        principal_name.len = ngx_strlen(name);
 		
         ngx_http_auth_spnego_store_delegated_creds(r, &principal_name, delegated_creds);
     }
 	
-	krb5_free_cred_contents(kcontext, &creds);
+    krb5_free_cred_contents(kcontext, &creds);
     /* Try to add the system realm to $remote_user if needed. */
     if (alcf->fqun && !ngx_strchr(r->headers_in.user.data, '@')) {
 #ifdef krb5_princ_realm
@@ -1201,223 +1199,223 @@ use_keytab(
 }
 
 static krb5_error_code ngx_http_auth_spnego_verify_server_credentials(ngx_http_request_t * r, krb5_context kcontext, ngx_str_t * principal_name, krb5_ccache ccache){
-	krb5_creds match_creds;
-	krb5_creds creds;
+    krb5_creds match_creds;
+    krb5_creds creds;
     krb5_timestamp now;
     krb5_error_code kerr = 0;
-	krb5_principal principal = NULL;
-	char * tgs_principal_name = NULL;
-	char * princ_name = NULL;
+    krb5_principal principal = NULL;
+    char * tgs_principal_name = NULL;
+    char * princ_name = NULL;
 	
-	memset (&match_creds, 0, sizeof(match_creds));
+    memset (&match_creds, 0, sizeof(match_creds));
     memset (&creds, 0, sizeof(creds));
 	
-	if((kerr = krb5_cc_get_principal(kcontext, ccache, &principal))){
-		spnego_log_error("Kerberos error: Cannot get principal from ccache");
-		spnego_log_krb5_error(kcontext, kerr);
-		goto done;
-	}
+    if((kerr = krb5_cc_get_principal(kcontext, ccache, &principal))){
+        spnego_log_error("Kerberos error: Cannot get principal from ccache");
+        spnego_log_krb5_error(kcontext, kerr);
+        goto done;
+    }
 	
-	if((kerr = krb5_unparse_name(kcontext, principal, &princ_name))){
-		spnego_log_error("Kerberos error: Cannot unparse principal");
-		spnego_log_krb5_error(kcontext, kerr);
-		goto done;
-	}
+    if((kerr = krb5_unparse_name(kcontext, principal, &princ_name))){
+        spnego_log_error("Kerberos error: Cannot unparse principal");
+        spnego_log_krb5_error(kcontext, kerr);
+        goto done;
+    }
 	
-	if(ngx_strncmp(principal_name->data, princ_name, ngx_strlen(princ_name)) != 0){
-		spnego_log_error("Kerberos error: Principal name mismatch");
-		spnego_debug0("Kerberos error: Principal name mismatch");
-		kerr = KRB5KRB_ERR_GENERIC;
-		goto done;
-	}
+    if(ngx_strncmp(principal_name->data, princ_name, ngx_strlen(princ_name)) != 0){
+        spnego_log_error("Kerberos error: Principal name mismatch");
+        spnego_debug0("Kerberos error: Principal name mismatch");
+        kerr = KRB5KRB_ERR_GENERIC;
+        goto done;
+    }
 	
-	size_t tgs_principal_name_size = (ngx_strlen(KRB5_TGS_NAME) + (principal->realm.length * 2) + 2) + 1;
-	tgs_principal_name = (char *) ngx_pcalloc(r->pool, tgs_principal_name_size);
-	ngx_snprintf(
-		(u_char *) tgs_principal_name, 
-		tgs_principal_name_size,
-		"%s/%*s@%*s", 
-		KRB5_TGS_NAME,
-		principal->realm.length,
-		principal->realm.data,
-		principal->realm.length,
-		principal->realm.data
-	);
+    size_t tgs_principal_name_size = (ngx_strlen(KRB5_TGS_NAME) + (principal->realm.length * 2) + 2) + 1;
+    tgs_principal_name = (char *) ngx_pcalloc(r->pool, tgs_principal_name_size);
+    ngx_snprintf(
+        (u_char *) tgs_principal_name, 
+        tgs_principal_name_size,
+        "%s/%*s@%*s", 
+        KRB5_TGS_NAME,
+        principal->realm.length,
+        principal->realm.data,
+        principal->realm.length,
+        principal->realm.data
+    );
 	
-	if ((kerr = krb5_parse_name(kcontext, tgs_principal_name, &match_creds.server))){
-		spnego_log_error("Kerberos error: Cannot parse principal: %s", tgs_principal_name);
-		spnego_log_krb5_error(kcontext, kerr);
-		goto done;		
-	}
+    if ((kerr = krb5_parse_name(kcontext, tgs_principal_name, &match_creds.server))){
+        spnego_log_error("Kerberos error: Cannot parse principal: %s", tgs_principal_name);
+        spnego_log_krb5_error(kcontext, kerr);
+        goto done;		
+    }
 	
     match_creds.client = principal;	
 	
-	if ((kerr = krb5_cc_retrieve_cred(kcontext, ccache, 0, &match_creds, &creds))){
-		spnego_log_error("Kerberos error: Cannot retrieve credentials");
-		spnego_log_krb5_error(kcontext, kerr);
-		goto done;		
-	}
+    if ((kerr = krb5_cc_retrieve_cred(kcontext, ccache, 0, &match_creds, &creds))){
+        spnego_log_error("Kerberos error: Cannot retrieve credentials");
+        spnego_log_krb5_error(kcontext, kerr);
+        goto done;		
+    }
 	
     if ((kerr = krb5_timeofday(kcontext, &now))) {
-		spnego_log_error("Kerberos error: Could not get current time");
-		spnego_log_krb5_error(kcontext, kerr);		
-		goto done;		
-	}
+        spnego_log_error("Kerberos error: Could not get current time");
+        spnego_log_krb5_error(kcontext, kerr);		
+        goto done;		
+    }
 	
     if ((now + RENEWAL_TIME) > creds.times.endtime) {
-		spnego_debug2("Credentials for %s have expired or will expire soon at %d - renewing", princ_name, creds.times.endtime);
-		kerr = KRB5KRB_AP_ERR_TKT_EXPIRED;
-	}else{
-		spnego_debug2("Credentials for %s will expire at %d", princ_name, creds.times.endtime);
-	}
+        spnego_debug2("Credentials for %s have expired or will expire soon at %d - renewing", princ_name, creds.times.endtime);
+        kerr = KRB5KRB_AP_ERR_TKT_EXPIRED;
+    }else{
+        spnego_debug2("Credentials for %s will expire at %d", princ_name, creds.times.endtime);
+    }
 done:
     if(principal) krb5_free_principal(kcontext, principal);
     if(match_creds.server) krb5_free_principal(kcontext, match_creds.server);
-	if(creds.client) krb5_free_cred_contents(kcontext, &creds);
+    if(creds.client) krb5_free_cred_contents(kcontext, &creds);
 	
-	return kerr;
+    return kerr;
 }
 
 static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(ngx_http_request_t * r, ngx_str_t * service_name, ngx_str_t * keytab_path, ngx_str_t * service_ccache) {
-	krb5_context kcontext = NULL;
+    krb5_context kcontext = NULL;
     krb5_keytab keytab = NULL;
     krb5_ccache ccache = NULL;
     krb5_error_code kerr = 0;
     krb5_principal principal = NULL;
-	krb5_get_init_creds_opt gicopts;
+    krb5_get_init_creds_opt gicopts;
     krb5_creds creds;
 		
-	char * principal_name = NULL;
+    char * principal_name = NULL;
     char * tgs_principal_name = NULL;
-	char kt_path[1024];
+    char kt_path[1024];
     char cc_name[1024];
 		
-	memset(&creds, 0, sizeof(creds));
+    memset(&creds, 0, sizeof(creds));
 		
-	if((kerr = krb5_init_context(&kcontext))){
-		spnego_log_error("Kerberos error: Cannot initialize kerberos context");
-		spnego_log_krb5_error(kcontext, kerr);
-		goto done;
-	}
+    if((kerr = krb5_init_context(&kcontext))){
+        spnego_log_error("Kerberos error: Cannot initialize kerberos context");
+        spnego_log_krb5_error(kcontext, kerr);
+        goto done;
+    }
 	
-	if(service_ccache->len && service_ccache->data){
-		ngx_snprintf(
-			(u_char *) cc_name, 
-			sizeof(cc_name), 
-			"FILE:%V%Z", 
-			service_ccache
-		);
+    if(service_ccache->len && service_ccache->data){
+        ngx_snprintf(
+            (u_char *) cc_name, 
+            sizeof(cc_name), 
+            "FILE:%V%Z", 
+            service_ccache
+        );
 		
-		if((kerr = krb5_cc_resolve(kcontext, cc_name, &ccache))){
-			spnego_log_error("Kerberos error: Cannot resolve ccache %s", cc_name);
-			spnego_log_krb5_error(kcontext, kerr);		
-			goto done;
-		}
-	}else{
-		 if ((kerr = krb5_cc_default(kcontext, &ccache))) {
-			spnego_log_error("Kerberos error: Cannot get default ccache");
-			spnego_log_krb5_error(kcontext, kerr);		
-			goto done;
-		}
+        if((kerr = krb5_cc_resolve(kcontext, cc_name, &ccache))){
+            spnego_log_error("Kerberos error: Cannot resolve ccache %s", cc_name);
+            spnego_log_krb5_error(kcontext, kerr);		
+            goto done;
+        }
+    }else{
+        if ((kerr = krb5_cc_default(kcontext, &ccache))) {
+            spnego_log_error("Kerberos error: Cannot get default ccache");
+            spnego_log_krb5_error(kcontext, kerr);		
+            goto done;
+        }
 		
-		ngx_snprintf(
-			(u_char *) cc_name, 
-			sizeof(cc_name), 
-			"%s:%s", 
-			krb5_cc_get_type(kcontext, ccache),
-			krb5_cc_get_name(kcontext, ccache)
-		);
-	}
+        ngx_snprintf(
+            (u_char *) cc_name, 
+            sizeof(cc_name), 
+            "%s:%s", 
+            krb5_cc_get_type(kcontext, ccache),
+            krb5_cc_get_name(kcontext, ccache)
+        );
+    }
 	
-	if((kerr = ngx_http_auth_spnego_verify_server_credentials(r, kcontext, service_name, ccache))){
-		if (kerr == KRB5_FCC_NOFILE || kerr == KRB5KRB_AP_ERR_TKT_EXPIRED) {
-			if((kerr = krb5_parse_name(kcontext, (char *) service_name->data, &principal))){
-				spnego_log_error("Kerberos error: Cannot parse principal %s", (char *) service_name->data);
-				spnego_log_krb5_error(kcontext, kerr);
-				goto done;
-			}
-			if((kerr = krb5_unparse_name(kcontext, principal, &principal_name))){
-				spnego_log_error("Kerberos error: Cannot unparse principal");
-				spnego_log_krb5_error(kcontext, kerr);
-				goto done;
-			}
-		}else{
-			spnego_log_error("Kerberos error: Error verifying server credentials");
-			spnego_log_krb5_error(kcontext, kerr);
-			goto done;
-		}
-	}else{
-		spnego_debug0("Server credentials valid");
-		goto done;
-	}
+    if((kerr = ngx_http_auth_spnego_verify_server_credentials(r, kcontext, service_name, ccache))){
+        if (kerr == KRB5_FCC_NOFILE || kerr == KRB5KRB_AP_ERR_TKT_EXPIRED) {
+            if((kerr = krb5_parse_name(kcontext, (char *) service_name->data, &principal))){
+                spnego_log_error("Kerberos error: Cannot parse principal %s", (char *) service_name->data);
+                spnego_log_krb5_error(kcontext, kerr);
+                goto done;
+            }
+            if((kerr = krb5_unparse_name(kcontext, principal, &principal_name))){
+                spnego_log_error("Kerberos error: Cannot unparse principal");
+                spnego_log_krb5_error(kcontext, kerr);
+                goto done;
+            }
+        }else{
+            spnego_log_error("Kerberos error: Error verifying server credentials");
+            spnego_log_krb5_error(kcontext, kerr);
+            goto done;
+        }
+    }else{
+        spnego_debug0("Server credentials valid");
+        goto done;
+    }
 
-	ngx_slab_pool_t * shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
+    ngx_slab_pool_t * shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
 	
-	ngx_shmtx_lock(&shpool->mutex);
+    ngx_shmtx_lock(&shpool->mutex);
 	
-	kerr = ngx_http_auth_spnego_verify_server_credentials(r, kcontext, service_name, ccache);
-	if((kerr != KRB5_FCC_NOFILE && kerr != KRB5KRB_AP_ERR_TKT_EXPIRED)) goto unlock;
+    kerr = ngx_http_auth_spnego_verify_server_credentials(r, kcontext, service_name, ccache);
+    if((kerr != KRB5_FCC_NOFILE && kerr != KRB5KRB_AP_ERR_TKT_EXPIRED)) goto unlock;
 
-	ngx_snprintf((u_char *) kt_path, sizeof(kt_path), "FILE:%V%Z", keytab_path);
+    ngx_snprintf((u_char *) kt_path, sizeof(kt_path), "FILE:%V%Z", keytab_path);
 			
-	if((kerr = krb5_kt_resolve(kcontext, kt_path, &keytab))){
-		spnego_log_error("Kerberos error: Cannot resolve keytab %s", kt_path);
-		spnego_log_krb5_error(kcontext, kerr);			
-		goto unlock;
-	}
+    if((kerr = krb5_kt_resolve(kcontext, kt_path, &keytab))){
+        spnego_log_error("Kerberos error: Cannot resolve keytab %s", kt_path);
+        spnego_log_krb5_error(kcontext, kerr);			
+        goto unlock;
+    }
 			
-	spnego_debug1("Obtaining new credentials for %s", principal_name);
+    spnego_debug1("Obtaining new credentials for %s", principal_name);
 			
-	krb5_get_init_creds_opt_init(&gicopts);
-	krb5_get_init_creds_opt_set_forwardable(&gicopts, 1);
+    krb5_get_init_creds_opt_init(&gicopts);
+    krb5_get_init_creds_opt_set_forwardable(&gicopts, 1);
 			
-	size_t tgs_principal_name_size = (ngx_strlen(KRB5_TGS_NAME) + (principal->realm.length * 2) + 2) + 1;
-	tgs_principal_name = (char *) ngx_pcalloc(r->pool, tgs_principal_name_size);
+    size_t tgs_principal_name_size = (ngx_strlen(KRB5_TGS_NAME) + (principal->realm.length * 2) + 2) + 1;
+    tgs_principal_name = (char *) ngx_pcalloc(r->pool, tgs_principal_name_size);
 						
-	ngx_snprintf(
-		(u_char *) tgs_principal_name, 
-		tgs_principal_name_size,
-		"%s/%*s@%*s", 
-		KRB5_TGS_NAME,
-		principal->realm.length,
-		principal->realm.data,
-		principal->realm.length,
-		principal->realm.data
-	);
+    ngx_snprintf(
+        (u_char *) tgs_principal_name, 
+        tgs_principal_name_size,
+        "%s/%*s@%*s", 
+        KRB5_TGS_NAME,
+        principal->realm.length,
+        principal->realm.data,
+        principal->realm.length,
+        principal->realm.data
+    );
 				
-	kerr = krb5_get_init_creds_keytab(
-		kcontext, 
-		&creds, 
-		principal, 
-		keytab,
-		0, 
-		tgs_principal_name, 
-		&gicopts
-	);
-	if(kerr){
-		spnego_log_error("Kerberos error: Cannot obtain credentials for principal %s", principal_name);
-		spnego_log_krb5_error(kcontext, kerr);				
-		goto unlock;
-	}
+    kerr = krb5_get_init_creds_keytab(
+        kcontext, 
+        &creds, 
+        principal, 
+        keytab,
+        0, 
+        tgs_principal_name, 
+        &gicopts
+    );
+    if(kerr){
+        spnego_log_error("Kerberos error: Cannot obtain credentials for principal %s", principal_name);
+        spnego_log_krb5_error(kcontext, kerr);				
+        goto unlock;
+    }
 
-	if((kerr = ngx_http_auth_spnego_store_krb5_creds(r, kcontext, principal, ccache, creds))){
-		spnego_debug0("ngx_http_auth_spnego_store_krb5_creds() failed");
-		goto unlock;
-	}
+    if((kerr = ngx_http_auth_spnego_store_krb5_creds(r, kcontext, principal, ccache, creds))){
+        spnego_debug0("ngx_http_auth_spnego_store_krb5_creds() failed");
+        goto unlock;
+    }
 		
 unlock:
-	ngx_shmtx_unlock(&shpool->mutex);
+    ngx_shmtx_unlock(&shpool->mutex);
 done:
-    if (!kerr) {
-		spnego_debug0("Successfully obtained server credentials");
-		setenv("KRB5CCNAME", cc_name, 1);
-	} else {
-		spnego_debug0("Failed to obtain server credentials");
-	}
+    if(!kerr){
+        spnego_debug0("Successfully obtained server credentials");
+        setenv("KRB5CCNAME", cc_name, 1);
+    }else{
+        spnego_debug0("Failed to obtain server credentials");
+    }
 	
     if (tgs_principal_name) ngx_pfree(r->pool, tgs_principal_name);
-	if (creds.client) krb5_free_cred_contents(kcontext, &creds);
-	if (keytab) krb5_kt_close(kcontext, keytab);
+    if (creds.client) krb5_free_cred_contents(kcontext, &creds);
+    if (keytab) krb5_kt_close(kcontext, keytab);
     if (ccache) krb5_cc_close(kcontext, ccache);
     if (kcontext) krb5_free_context(kcontext);
 		
@@ -1487,23 +1485,29 @@ ngx_http_auth_spnego_auth_user_gss(
         }
         spnego_debug1("my_gss_name %s", human_readable_gss_name.value);
 		
-		if(alcf->constrained_delegation){
-			ngx_str_t service_name = ngx_null_string;
-			service_name.data = (u_char *) service.value;
-			service_name.len = service.length;
+        if(alcf->constrained_delegation){
+            ngx_str_t service_name = ngx_null_string;
+            service_name.data = (u_char *) service.value;
+            service_name.len = service.length;
 			
-			ngx_http_auth_spnego_obtain_server_credentials(
-				r, 
-				&service_name,
-				&alcf->keytab,
-				&alcf->service_ccache
-			);
-		}
+            ngx_http_auth_spnego_obtain_server_credentials(
+                r, 
+                &service_name,
+                &alcf->keytab,
+                &alcf->service_ccache
+            );
+        }
 		
         /* Obtain credentials */
-        major_status = gss_acquire_cred(&minor_status, my_gss_name,
-                GSS_C_INDEFINITE, GSS_C_NO_OID_SET, (alcf->constrained_delegation ? GSS_C_BOTH : GSS_C_ACCEPT), &my_gss_creds,
-                NULL, NULL);
+        major_status = gss_acquire_cred(
+            &minor_status, my_gss_name,
+            GSS_C_INDEFINITE, 
+	    GSS_C_NO_OID_SET, 
+	    (alcf->constrained_delegation ? GSS_C_BOTH : GSS_C_ACCEPT), 
+	    &my_gss_creds, 
+	    NULL, 
+	    NULL
+        );
 		
         if (GSS_ERROR(major_status)) {
             spnego_log_error("%s Used service principal: %s", get_gss_error(
@@ -1543,10 +1547,9 @@ ngx_http_auth_spnego_auth_user_gss(
         }
         ngx_encode_base64(&ctx->token_out_b64, &spnego_token);
         gss_release_buffer(&minor_status2, &output_token);
-    }
-	else {
+    } else {
         ctx->token_out_b64.len = 0;
-	}
+    }
 
     /* getting user name at the other end of the request */
     major_status = gss_display_name(&minor_status, client_name, &output_token, NULL);
@@ -1600,14 +1603,14 @@ ngx_http_auth_spnego_auth_user_gss(
     }
     	
     if(alcf->delegate_credentials){
-		creds_info creds = {
-			delegated_creds,
-			TYPE_GSS_CRED_ID_T
-		};
+        creds_info creds = {
+            delegated_creds,
+            TYPE_GSS_CRED_ID_T
+        };
 		
-		ngx_str_t principal_name = ngx_null_string;
-		principal_name.data = (u_char *) output_token.value;
-		principal_name.len = output_token.length;
+        ngx_str_t principal_name = ngx_null_string;
+        principal_name.data = (u_char *) output_token.value;
+        principal_name.len = output_token.length;
 		
         ngx_http_auth_spnego_store_delegated_creds(r, &principal_name, creds);
     }
@@ -1625,8 +1628,7 @@ end:
         gss_release_name(&minor_status, &client_name);
 
     if (gss_context != GSS_C_NO_CONTEXT)
-        gss_delete_sec_context(&minor_status, &gss_context,
-                GSS_C_NO_BUFFER);
+        gss_delete_sec_context(&minor_status, &gss_context, GSS_C_NO_BUFFER);
 
     if (my_gss_name != GSS_C_NO_NAME)
         gss_release_name(&minor_status, &my_gss_name);

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -340,7 +340,9 @@ ngx_http_auth_spnego_create_loc_conf(
     conf->force_realm = NGX_CONF_UNSET;
     conf->allow_basic = NGX_CONF_UNSET;
     conf->auth_princs = NGX_CONF_UNSET_PTR;
+#if (NGX_PCRE)
     conf->auth_princs_regex = NGX_CONF_UNSET_PTR;
+#endif
     conf->map_to_local = NGX_CONF_UNSET;
     conf->delegate_credentials = NGX_CONF_UNSET;
     conf->constrained_delegation = NGX_CONF_UNSET;
@@ -372,7 +374,10 @@ ngx_http_auth_spnego_merge_loc_conf(
     ngx_conf_merge_off_value(conf->allow_basic, prev->allow_basic, 1);
 	
     ngx_conf_merge_ptr_value(conf->auth_princs, prev->auth_princs, NGX_CONF_UNSET_PTR);
+
+#if (NGX_PCRE)
     ngx_conf_merge_ptr_value(conf->auth_princs_regex, prev->auth_princs_regex, NGX_CONF_UNSET_PTR);
+#endif
 	
     ngx_conf_merge_off_value(conf->map_to_local, prev->map_to_local, 0);
 


### PR DESCRIPTION
Implemented support for delegation (unconstrained and constrained) and authorizing principals using a regex pattern. README.md has been changed to document these new features. 

Authorizing principals using a regex pattern can be enabled using the auth_gss_authorized_principal_regex directive.

Unconstrained delegation can be enabled using the auth_gss_delegate_credentials directive. Constrained delegation (S4U2proxy) can be enabled using the auth_gss_constrained_delegation directive. Constrained delegation is currently only supported using the negotiate authentication scheme. 

These new features has only been tested using MIT Kerberos. Use at your own risk if using Heimdal Kerberos. Both unconstrained and constrained delegation has been tested for concurrency. 
