### PR TITLE
Module wouldn't compile, 'kcontext' is used uninitialized

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -751,7 +751,7 @@ static ngx_int_t
 ngx_http_auth_spnego_store_delegated_creds(ngx_http_request_t *r,
                                            ngx_str_t *principal_name,
                                            creds_info delegated_creds) {
-    krb5_context kcontext;
+    krb5_context kcontext = NULL;
     krb5_principal principal = NULL;
     krb5_ccache ccache = NULL;
     krb5_error_code kerr = 0;


### PR DESCRIPTION
Fixing the error below during nginx build. This occurred with nginx version 1.22.0. I haven't tried previous versions. 

ngx_http_auth_spnego_module.c:761:9: error: variable 'kcontext' is used uninitialized whenever 'if' condition is true [-Werror,-Wsometimes-uninitialized]