### PR TITLE
Three minor fixes

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -519,6 +519,9 @@ ngx_http_auth_spnego_headers_basic_only(ngx_http_request_t *r,
     }
 
     r->headers_out.www_authenticate->hash = 1;
+#if defined(nginx_version) && nginx_version >= 1023000
+    r->headers_out.www_authenticate->next = NULL;
+#endif
     r->headers_out.www_authenticate->key.len = sizeof("WWW-Authenticate") - 1;
     r->headers_out.www_authenticate->key.data = (u_char *)"WWW-Authenticate";
     r->headers_out.www_authenticate->value.len = value.len;
@@ -555,6 +558,9 @@ ngx_http_auth_spnego_headers(ngx_http_request_t *r,
     }
 
     r->headers_out.www_authenticate->hash = 1;
+#if defined(nginx_version) && nginx_version >= 1023000
+    r->headers_out.www_authenticate->next = NULL;
+#endif
     r->headers_out.www_authenticate->key.len = sizeof("WWW-Authenticate") - 1;
     r->headers_out.www_authenticate->key.data = (u_char *)"WWW-Authenticate";
     r->headers_out.www_authenticate->value.len = value.len;
@@ -576,6 +582,9 @@ ngx_http_auth_spnego_headers(ngx_http_request_t *r,
         }
 
         r->headers_out.www_authenticate->hash = 2;
+#if defined(nginx_version) && nginx_version >= 1023000
+        r->headers_out.www_authenticate->next = NULL;
+#endif
         r->headers_out.www_authenticate->key.len =
             sizeof("WWW-Authenticate") - 1;
         r->headers_out.www_authenticate->key.data =
@@ -768,7 +777,7 @@ static ngx_int_t
 ngx_http_auth_spnego_store_delegated_creds(ngx_http_request_t *r,
                                            ngx_str_t *principal_name,
                                            creds_info delegated_creds) {
-    krb5_context kcontext;
+    krb5_context kcontext = NULL;
     krb5_principal principal = NULL;
     krb5_ccache ccache = NULL;
     krb5_error_code kerr = 0;

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -1281,6 +1281,10 @@ static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(
     krb5_principal principal = NULL;
     krb5_get_init_creds_opt gicopts;
     krb5_creds creds;
+#ifdef HEIMDAL_DEPRECATED
+    // only used to call krb5_get_init_creds_opt_alloc() in newer heimdal
+    krb5_get_init_creds_opt *gicopts_l;
+#endif
 
     char *principal_name = NULL;
     char *tgs_principal_name = NULL;
@@ -1363,7 +1367,12 @@ static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(
 
     spnego_debug1("Obtaining new credentials for %s", principal_name);
 
+#ifndef HEIMDAL_DEPRECATED
     krb5_get_init_creds_opt_init(&gicopts);
+#else
+    gicopts_l = &gicopts;
+    krb5_get_init_creds_opt_alloc(kcontext, &gicopts_l);
+#endif
     krb5_get_init_creds_opt_set_forwardable(&gicopts, 1);
 
     size_t tgs_principal_name_size =


### PR DESCRIPTION
Hello,

I was building spnego module on FreeBSD 13 with nginx 1.23.4 and ran into a couple of problems:
1) clang warns about uninitialized kcontex variable
2) clang warns about 'next' field uninitialized
3) heimdal deprecates krb5_get_init_creds_opt_init()

Additionally, I have my own tests which fail if there is an unexpected shared memory zone in the configuration (I'm using lua module which has to create some specific zones). So I moved shared memory zone creation to a later stage when the module can be sure that it is needed. I also added an option to configure the zone name if needed. 

Changes seem to solve my problems and don't break anything for other platform/libraries. I tested it works on debian/ubuntu(MIT based) and bsd system (heimdal)

I guess proper heimdal patch should be more involved but this one works for me. So good enough, I guess.

Let me know if I should split my PR into three separate.

Regards,
oxpa