### PR TITLE
Fix check of no realm in username

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -885,7 +885,7 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
     krb5_get_init_creds_opt *gic_options = NULL;
     int kret = 0;
     char *name = NULL;
-    char *p = NULL;
+    unsigned char *p = NULL;
 
     code = krb5_init_context(&kcontext);
     if (code) {
@@ -933,7 +933,8 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
     free(name);
     name = NULL;
 
-    p = ngx_strchr(r->headers_in.user.data, '@');
+    p = ngx_strlchr(r->headers_in.user.data,
+                    r->headers_in.user.data + r->headers_in.user.len, '@');
     user.len = r->headers_in.user.len + 1;
     if (NULL == p) {
         if (alcf->force_realm && alcf->realm.len && alcf->realm.data) {


### PR DESCRIPTION
Since headers_in.user.data is not terminated by NUL, p is not NULL for a no-realm username if the password contains '@'.
This patch fixes it by replacing `ngx_strchr` with `ngx_strlchr`.
