### PR TITLE
Fix incorrect logging in krb5_parse_name() error handling

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -883,7 +883,6 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
     krb5_principal server = NULL;
     krb5_creds creds;
     krb5_get_init_creds_opt *gic_options = NULL;
-    int kret = 0;
     char *name = NULL;
     char *p = NULL;
 
@@ -915,9 +914,9 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
                      &host_name, &alcf->realm);
     }
 
-    kret = krb5_parse_name(kcontext, (const char *)service.data, &server);
+    code = krb5_parse_name(kcontext, (const char *)service.data, &server);
 
-    if (kret) {
+    if (code) {
         spnego_log_error("Kerberos error:  Unable to parse service name");
         spnego_log_krb5_error(kcontext, code);
         spnego_error(NGX_ERROR);


### PR DESCRIPTION
The Svace static analysis tool identified a potential issue in the function `ngx_http_auth_spnego_basic()`, where the variable `code` might incorrectly store the value from `krb5_init_context() `instead of the return value from `krb5_parse_name()`, which causes incorrect error logging. In the current situation, line 922
```c
spnego_log_krb5_error(kcontext, code);
```
logs the value of `code`, which was previously set by `krb5_init_context()`, instead of the expected return value from `krb5_parse_name()`
Moreover, `krb5_parse_name()` returns a value of type `krb5_error_code`, while `kret` does not match this data type and is not used elsewhere in file. Keeping the variable `kret` may be unnecessary. Instead, the return value of `krb5_parse_name()` should be directly assigned to `code`

To resolve this issue, `kret` should be removed, and `code` should be used to store the return value of `krb5_parse_name()` to ensure correct error logging:

```diff
diff --git a/ngx_http_auth_spnego_module.c b/ngx_http_auth_spnego_module.c
index 4a89065..dfdead6 100644
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -883,7 +883,6 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
     krb5_principal server = NULL;
     krb5_creds creds;
     krb5_get_init_creds_opt *gic_options = NULL;
-    int kret = 0;
     char *name = NULL;
     char *p = NULL;
 
@@ -915,9 +914,9 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
                      &host_name, &alcf->realm);
     }
 
-    kret = krb5_parse_name(kcontext, (const char *)service.data, &server);
+    code = krb5_parse_name(kcontext, (const char *)service.data, &server);
 
-    if (kret) {
+    if (code) {
         spnego_log_error("Kerberos error:  Unable to parse service name");
         spnego_log_krb5_error(kcontext, code);
         spnego_error(NGX_ERROR);
```