### PR TITLE
(krb5_realm_length(principal->realm) * 2) has no explicit type cast 

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -1382,7 +1382,7 @@ static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(
     krb5_get_init_creds_opt_set_forwardable(&gicopts, 1);
 
     size_t tgs_principal_name_size =
-        (ngx_strlen(KRB5_TGS_NAME) + (krb5_realm_length(principal->realm) * 2) + 2) + 1;
+        (ngx_strlen(KRB5_TGS_NAME) + ((size_t)krb5_realm_length(principal->realm) * 2) + 2) + 1;
     tgs_principal_name = (char *)ngx_pcalloc(r->pool, tgs_principal_name_size);
 
     ngx_snprintf((u_char *)tgs_principal_name, tgs_principal_name_size,


### PR DESCRIPTION
Hello! I was analyzing your module with **Svace SAST** tool and found a vulnerability here:

https://github.com/stnoonan/spnego-http-auth-nginx-module/blob/60f081115dd91f8ce258a735d90638f918cd36d5/ngx_http_auth_spnego_module.c#L1384-L1386

`krb5_realm_length` returns value of `length` variable from `principal->realm`.  `principal->realm`  itself has data type `krb5_data`, `length` inside `krb5_data` has `unsigned int` type: https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/types/krb5_data.html. So it may be an integer overflow while multiplying  `krb5_realm_length(principal->realm)` result without cast to the larger type.

It also matters because potential integer overflow makes `tgs_principal_name_size` variable smaller than it have to and it leads to the loss of data here:

https://github.com/stnoonan/spnego-http-auth-nginx-module/blob/60f081115dd91f8ce258a735d90638f918cd36d5/ngx_http_auth_spnego_module.c#L1388-L1391

Fix itself is really simple. Hope it helps!

_Found by Linux Verification Center (linuxtesting.org) with SVACE._