### PR TITLE
docs: fix valid value for `auth_gss_format_full`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ These options should ONLY be specified if you have a keytab containing
 privileged principals.  In nearly all cases, you should not put these
 in the configuration file, as `gss_accept_sec_context` will do the right
 thing.
-* `auth_gss_realm`: Kerberos realm name.  If this is specified, the realm is only passed to the nginx variable $remote_user if it differs from this default.  To override this behavior, set *auth_gss_format_full* to 1 in your configuration.
+* `auth_gss_realm`: Kerberos realm name.  If this is specified, the realm is only passed to the nginx variable $remote_user if it differs from this default.  To override this behavior, set *auth_gss_format_full* to `on` in your configuration.
 * `auth_gss_service_name`: service principal name to use when acquiring
   credentials.
 


### PR DESCRIPTION
`1` is not valid a value for `auth_gss_format_full`. 


Saw this locally 

```
nginx: [emerg] invalid value "1" in "auth_gss_format_full" directive, it must be "on" or "off" in /etc/nginx/conf.d/default.conf:87
```