### PR TITLE
Krb5 length overflow

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -1227,11 +1227,11 @@ static krb5_error_code ngx_http_auth_spnego_verify_server_credentials(
         kerr = KRB5KRB_ERR_GENERIC;
         goto done;
     }
+    
     size_t realm_len = krb5_realm_length(principal->realm);
     size_t tgs_principal_name_size = 
             (ngx_strlen(KRB5_TGS_NAME) + (realm_len * 2 ) + 2) + 1; 
-    //size_t tgs_principal_name_size =
-    //    (ngx_strlen(KRB5_TGS_NAME) + (krb5_realm_length(principal->realm) * 2) + 2) + 1;
+
     tgs_principal_name = (char *)ngx_pcalloc(r->pool, tgs_principal_name_size);
     ngx_snprintf((u_char *)tgs_principal_name, tgs_principal_name_size,
                  "%s/%*s@%*s", KRB5_TGS_NAME, krb5_realm_length(principal->realm),

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -1227,9 +1227,11 @@ static krb5_error_code ngx_http_auth_spnego_verify_server_credentials(
         kerr = KRB5KRB_ERR_GENERIC;
         goto done;
     }
-
-    size_t tgs_principal_name_size =
-        (ngx_strlen(KRB5_TGS_NAME) + (krb5_realm_length(principal->realm) * 2) + 2) + 1;
+    size_t realm_len = krb5_realm_length(principal->realm);
+    size_t tgs_principal_name_size = 
+            (ngx_strlen(KRB5_TGS_NAME) + (realm_len * 2 ) + 2) + 1; 
+    //size_t tgs_principal_name_size =
+    //    (ngx_strlen(KRB5_TGS_NAME) + (krb5_realm_length(principal->realm) * 2) + 2) + 1;
     tgs_principal_name = (char *)ngx_pcalloc(r->pool, tgs_principal_name_size);
     ngx_snprintf((u_char *)tgs_principal_name, tgs_principal_name_size,
                  "%s/%*s@%*s", KRB5_TGS_NAME, krb5_realm_length(principal->realm),


### PR DESCRIPTION
 The Svace static analysis tool identified a potential issue in the function `ngx_http_auth_spnego_verify_server_credentials`, specifically a possible integer overflow in an arithmetic expression. 
Specifically, the following expression may trigger undefined behavior on 32-bit architectures:

```c
(ngx_strlen(KRB5_TGS_NAME) + (krb5_realm_length(...) * 2) + 2) + 1;
```
`krb5_realm_length()` returns `unsigned int`, on 32-bit arithmetic the `* 2` can wrap for a realm length ≥ `UINT_MAX / 2`, potentially resulting memory corruption.

So, the solutions is to replace the original expression with the following: 

```diff
diff --git a/ngx_http_auth_spnego_module.c b/ngx_http_auth_spnego_module.c
index dc71c3a..d352b51 100644
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -1227,9 +1227,11 @@ static krb5_error_code ngx_http_auth_spnego_verify_server_credentials(
         kerr = KRB5KRB_ERR_GENERIC;
         goto done;
     }
+    
+    size_t realm_len = krb5_realm_length(principal->realm);
+    size_t tgs_principal_name_size = 
+            (ngx_strlen(KRB5_TGS_NAME) + (realm_len * 2 ) + 2) + 1; 
 
-    size_t tgs_principal_name_size =
-        (ngx_strlen(KRB5_TGS_NAME) + (krb5_realm_length(principal->realm) * 2) + 2) + 1;
```