### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,6 +2,9 @@ name: Build and test
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
 
   build-test:


### PR DESCRIPTION
Potential fix for [https://github.com/stnoonan/spnego-http-auth-nginx-module/security/code-scanning/1](https://github.com/stnoonan/spnego-http-auth-nginx-module/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow or to the specific job (`build-test`). This block should define the least privileges required for the workflow to function correctly. Based on the workflow's actions, the `contents: read` permission is sufficient for reading repository files, and no write permissions are necessary.

The `permissions` block will be added at the root level of the workflow to apply to all jobs, ensuring consistency and reducing the risk of privilege escalation.
