### PR TITLE
Spnego module builtins

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -898,7 +898,7 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
                                      ngx_http_auth_spnego_ctx_t *ctx,
                                      ngx_http_auth_spnego_loc_conf_t *alcf) {
     ngx_str_t host_name;
-    ngx_str_t service;
+    ngx_str_t service = ngx_null_string;
     ngx_str_t user;
     user.data = NULL;
     ngx_str_t new_user;

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -919,7 +919,19 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    host_name = r->headers_in.host->value;
+    /*
+     * Use nginx's parsed request host when available. This is populated from
+     * Host/:authority by core request parsing and avoids dereferencing a NULL
+     * host header pointer on HTTP/2 and HTTP/3 requests.
+     */
+    host_name = r->headers_in.server;
+    if (host_name.len == 0 && r->headers_in.host != NULL) {
+        host_name = r->headers_in.host->value;
+    }
+    if (host_name.len == 0) {
+        spnego_log_error("Client sent request without a valid host name");
+        spnego_error(NGX_ERROR);
+    }
     service.len = alcf->srvcname.len + alcf->realm.len + 3;
 
     if (ngx_strchr(alcf->srvcname.data, '/')) {
@@ -997,8 +1009,11 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
                 r->headers_in.user.len -= alcf->realm.len + 1;
             }
         } else if (alcf->force_realm) {
-            *p = '\0';
-            user.len = ngx_strlen(r->headers_in.user.data) + 1;
+            ngx_str_t short_user;
+
+            short_user.data = r->headers_in.user.data;
+            short_user.len = p - r->headers_in.user.data;
+            user.len = short_user.len + 1;
             if (alcf->realm.len && alcf->realm.data)
                 user.len += alcf->realm.len + 1;
             user.data = ngx_pcalloc(r->pool, user.len);
@@ -1007,11 +1022,10 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
                 spnego_error(NGX_ERROR);
             }
             if (alcf->realm.len && alcf->realm.data)
-                ngx_snprintf(user.data, user.len, "%s@%V%Z",
-                             r->headers_in.user.data, &alcf->realm);
+                ngx_snprintf(user.data, user.len, "%V@%V%Z", &short_user,
+                             &alcf->realm);
             else
-                ngx_snprintf(user.data, user.len, "%s%Z",
-                             r->headers_in.user.data);
+                ngx_snprintf(user.data, user.len, "%V%Z", &short_user);
             /*
              * Rewrite $remote_user with the forced realm.
              * If the forced realm is shorter than the


### PR DESCRIPTION
Replaces manual host header parsing with nginx-native `r->headers_in.server` and fixes unsafe username mutation to prevent crashes and ensure correct SPN generation.

The original approach in PR #168 manually scanned for `:authority` which bypassed nginx's robust host parsing, leading to potential incorrect Kerberos Service Principal Name (SPN) formation and a crash on null host. This PR adopts nginx's canonical `r->headers_in.server` for host resolution and refactors username handling to avoid in-place buffer mutations, making the module more resilient and aligned with nginx's internal APIs.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-537a4a1a-f74e-4391-b831-4c852d2b56b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-537a4a1a-f74e-4391-b831-4c852d2b56b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication principal/SPN construction and `$remote_user` rewriting; low code churn but mistakes here can break Kerberos auth or alter identity mapping.
> 
> **Overview**
> Fixes SPNEGO basic-auth SPN construction by resolving the request host via nginx’s parsed `r->headers_in.server` (with a safe fallback to the raw `Host` header) and explicitly erroring when no valid host is available, avoiding NULL dereferences on HTTP/2/3.
> 
> Refactors `auth_gss_force_realm` username rewriting to avoid in-place mutation of `r->headers_in.user` (no more `*p = '\0'`), instead building the forced-realm principal from a bounded `short_user` slice before updating `$remote_user`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 535cc99a3c75a137bb00cd129de117e320fbf7ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->