### PR TITLE
Fix host handling crash path and harden auth module memory/error handling

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -463,7 +463,6 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
 static ngx_int_t ngx_http_auth_spnego_get_handler(ngx_http_request_t *r,
                                                   ngx_http_variable_value_t *v,
                                                   uintptr_t data) {
-    v->not_found = 1;
     return NGX_OK;
 }
 

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -898,7 +898,7 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
                                      ngx_http_auth_spnego_ctx_t *ctx,
                                      ngx_http_auth_spnego_loc_conf_t *alcf) {
     ngx_str_t host_name;
-    ngx_str_t service;
+    ngx_str_t service = ngx_null_string;
     ngx_str_t user;
     user.data = NULL;
     ngx_str_t new_user;

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -919,7 +919,19 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    host_name = r->headers_in.host->value;
+    /*
+     * Use nginx's parsed request host when available. This is populated from
+     * Host/:authority by core request parsing and avoids dereferencing a NULL
+     * host header pointer on HTTP/2 and HTTP/3 requests.
+     */
+    host_name = r->headers_in.server;
+    if (host_name.len == 0 && r->headers_in.host != NULL) {
+        host_name = r->headers_in.host->value;
+    }
+    if (host_name.len == 0) {
+        spnego_log_error("Client sent request without a valid host name");
+        spnego_error(NGX_ERROR);
+    }
     service.len = alcf->srvcname.len + alcf->realm.len + 3;
 
     if (ngx_strchr(alcf->srvcname.data, '/')) {
@@ -997,8 +1009,11 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
                 r->headers_in.user.len -= alcf->realm.len + 1;
             }
         } else if (alcf->force_realm) {
-            *p = '\0';
-            user.len = ngx_strlen(r->headers_in.user.data) + 1;
+            ngx_str_t short_user;
+
+            short_user.data = r->headers_in.user.data;
+            short_user.len = p - r->headers_in.user.data;
+            user.len = short_user.len + 1;
             if (alcf->realm.len && alcf->realm.data)
                 user.len += alcf->realm.len + 1;
             user.data = ngx_pcalloc(r->pool, user.len);
@@ -1007,11 +1022,10 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
                 spnego_error(NGX_ERROR);
             }
             if (alcf->realm.len && alcf->realm.data)
-                ngx_snprintf(user.data, user.len, "%s@%V%Z",
-                             r->headers_in.user.data, &alcf->realm);
+                ngx_snprintf(user.data, user.len, "%V@%V%Z", &short_user,
+                             &alcf->realm);
             else
-                ngx_snprintf(user.data, user.len, "%s%Z",
-                             r->headers_in.user.data);
+                ngx_snprintf(user.data, user.len, "%V%Z", &short_user);
             /*
              * Rewrite $remote_user with the forced realm.
              * If the forced realm is shorter than the

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -111,9 +111,9 @@ const char *get_gss_error(ngx_pool_t *p, OM_uint32 error_status, char *prefix) {
     do {
         maj_stat = gss_display_status(&min_stat, error_status, GSS_C_MECH_CODE,
                                       GSS_C_NO_OID, &msg_ctx, &status_string);
-        if (sizeof(buf) > len + status_string.length + 1) {
-            ngx_sprintf((u_char *)buf + len, "%s:%Z",
-                        (char *)status_string.value);
+        if (sizeof(buf) > len + status_string.length + 2) {
+            ngx_snprintf((u_char *)buf + len, sizeof(buf) - len, "%*s:%Z",
+                         status_string.length, status_string.value);
             len += (status_string.length + 1);
         }
         gss_release_buffer(&min_stat, &status_string);
@@ -312,7 +312,7 @@ static void *ngx_http_auth_spnego_create_loc_conf(ngx_conf_t *cf) {
 
     conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_auth_spnego_loc_conf_t));
     if (NULL == conf) {
-        return NGX_CONF_ERROR;
+        return NULL;
     }
 
     conf->protect = NGX_CONF_UNSET;
@@ -463,6 +463,7 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
 static ngx_int_t ngx_http_auth_spnego_get_handler(ngx_http_request_t *r,
                                                   ngx_http_variable_value_t *v,
                                                   uintptr_t data) {
+    v->not_found = 1;
     return NGX_OK;
 }
 
@@ -470,6 +471,9 @@ static ngx_int_t ngx_http_auth_spnego_set_variable(ngx_http_request_t *r,
                                                    ngx_str_t *name,
                                                    ngx_str_t *value) {
     u_char *lowercase = ngx_palloc(r->pool, name->len);
+    if (lowercase == NULL) {
+        return NGX_ERROR;
+    }
 
     ngx_uint_t key = ngx_hash_strlow(lowercase, name->data, name->len);
     ngx_pfree(r->pool, lowercase);
@@ -482,6 +486,9 @@ static ngx_int_t ngx_http_auth_spnego_set_variable(ngx_http_request_t *r,
 
     v->len = value->len;
     v->data = value->data;
+    v->valid = 1;
+    v->not_found = 0;
+    v->no_cacheable = 1;
 
     return NGX_OK;
 }
@@ -761,8 +768,8 @@ static krb5_error_code ngx_http_auth_spnego_store_gss_creds(
 }
 
 static void ngx_http_auth_spnego_krb5_destroy_ccache(void *data) {
-    krb5_context kcontext;
-    krb5_ccache ccache;
+    krb5_context kcontext = NULL;
+    krb5_ccache ccache = NULL;
     krb5_error_code kerr = 0;
 
     char *ccname = (char *)data;
@@ -783,8 +790,13 @@ done:
 
 static char *ngx_http_auth_spnego_replace(ngx_http_request_t *r, char *str,
                                           char find, char replace) {
-    char *result = (char *)ngx_palloc(r->pool, ngx_strlen(str) + 1);
-    ngx_memcpy(result, str, ngx_strlen(str) + 1);
+    size_t str_len = ngx_strlen(str);
+    char *result = (char *)ngx_palloc(r->pool, str_len + 1);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    ngx_memcpy(result, str, str_len + 1);
 
     char *index = NULL;
     while ((index = ngx_strchr(result, find)) != NULL) {
@@ -803,6 +815,7 @@ ngx_http_auth_spnego_store_delegated_creds(ngx_http_request_t *r,
     krb5_error_code kerr = 0;
     char *ccname = NULL;
     char *escaped = NULL;
+    bool ccname_owned_by_cleanup = false;
 
     if (!delegated_creds.data) {
         spnego_log_error(
@@ -820,7 +833,7 @@ ngx_http_auth_spnego_store_delegated_creds(ngx_http_request_t *r,
 
     if ((kerr = krb5_parse_name(kcontext, (char *)principal_name->data,
                                 &principal))) {
-        spnego_log_error("Kerberos error: Cannot parse principal %s",
+        spnego_log_error("Kerberos error: Cannot parse principal \"%V\"",
                          principal_name);
         spnego_log_krb5_error(kcontext, kerr);
         goto done;
@@ -828,13 +841,18 @@ ngx_http_auth_spnego_store_delegated_creds(ngx_http_request_t *r,
 
     escaped =
         ngx_http_auth_spnego_replace(r, (char *)principal_name->data, '/', '_');
+    if (escaped == NULL) {
+        kerr = ENOMEM;
+        goto done;
+    }
 
     size_t ccname_size = (ngx_strlen("FILE:") + ngx_strlen(P_tmpdir) +
                           ngx_strlen("/") + ngx_strlen(escaped)) +
                          1;
     ccname = (char *)ngx_pcalloc(r->pool, ccname_size);
     if (NULL == ccname) {
-        return NGX_ERROR;
+        kerr = ENOMEM;
+        goto done;
     }
 
     ngx_snprintf((u_char *)ccname, ccname_size, "FILE:%s/%*s", P_tmpdir,
@@ -874,15 +892,17 @@ ngx_http_auth_spnego_store_delegated_creds(ngx_http_request_t *r,
 
     ngx_pool_cleanup_t *cln = ngx_pool_cleanup_add(r->pool, 0);
     if (NULL == cln) {
-        return NGX_ERROR;
+        kerr = ENOMEM;
+        goto done;
     }
 
     cln->handler = ngx_http_auth_spnego_krb5_destroy_ccache;
     cln->data = ccname;
+    ccname_owned_by_cleanup = true;
 done:
     if (escaped)
         ngx_pfree(r->pool, escaped);
-    if (ccname)
+    if (ccname && !ccname_owned_by_cleanup)
         ngx_pfree(r->pool, ccname);
     if (principal)
         krb5_free_principal(kcontext, principal);
@@ -1545,7 +1565,11 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
                                            "gss_display_name() failed"),
                              (u_char *)service.value);
         }
-        spnego_debug1("my_gss_name %s", human_readable_gss_name.value);
+        spnego_debug2("my_gss_name %*s", human_readable_gss_name.length,
+                      human_readable_gss_name.value);
+        if (human_readable_gss_name.length) {
+            gss_release_buffer(&minor_status2, &human_readable_gss_name);
+        }
 
         if (alcf->constrained_delegation) {
             ngx_str_t service_name = ngx_null_string;
@@ -1620,6 +1644,9 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
         /* Apply local rules to map Kerberos Principals to short names */
         if (alcf->map_to_local) {
             gss_OID mech_type = discard_const(gss_mech_krb5);
+            if (output_token.length) {
+                gss_release_buffer(&minor_status2, &output_token);
+            }
             output_token = (gss_buffer_desc)GSS_C_EMPTY_BUFFER;
             major_status = gss_localname(&minor_status, client_name, mech_type,
                                          &output_token);


### PR DESCRIPTION
- avoid NULL deref on request host path by using nginx parsed host
- stop mutating r->headers_in.user buffer in force_realm path
- initialize service to satisfy -Werror=maybe-uninitialized
- fix cleanup lifetime/double-free risk for delegated ccache name
- fix invalid %s logging of ngx_str_t principal
- fix uninitialized locals in ccache cleanup
- fix GSS buffer handling/leaks in display/map-to-local paths
- keep delegated credential $krb5_cc_name behavior intact (regression fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and credential-handling code paths (SPNEGO/Kerberos), so regressions could affect login flows or delegated credential propagation, though changes are mostly defensive and error-handling focused.
> 
> **Overview**
> Fixes several crash/leak/error-handling paths in `ngx_http_auth_spnego_module.c` around host parsing, variable setting, and GSS/Kerberos credential management.
> 
> Key changes: use `r->headers_in.server` (with fallback) to avoid NULL deref when building the service principal on HTTP/2/HTTP/3; stop mutating the original `r->headers_in.user` buffer when forcing realms; harden allocation failures and correct return values; ensure `$krb5_cc_name` is properly set as a valid/no-cache variable; and tighten cleanup/lifetime management for delegated credential ccache names to avoid leaks/double-frees.
> 
> Also fixes formatting/logging of variable-length GSS/ngx strings and releases GSS buffers correctly when displaying names or mapping to local names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 820d89a3db0d8755dfebcf39868fa6e5a26b8542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->