### PR TITLE
Guard Basic auth password allocation size

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -1112,6 +1112,10 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
         spnego_error(NGX_ERROR);
     }
 
+    if (r->headers_in.passwd.len > 1024) {
+        spnego_log_error("Password too long");
+        spnego_error(NGX_DECLINED);
+    }
     char *passwd = ngx_pnalloc(r->pool, r->headers_in.passwd.len + 1);
     if (passwd == NULL) {
         spnego_log_error("Not enough memory");

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -1112,8 +1112,8 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
         spnego_error(NGX_ERROR);
     }
 
-    if (r->headers_in.passwd.len > 1024) {
-        spnego_log_error("Password too long");
+    if (r->headers_in.passwd.len >= (size_t)(-1)) {
+        spnego_log_error("Password length exceeds maximum");
         spnego_error(NGX_DECLINED);
     }
     char *passwd = ngx_pnalloc(r->pool, r->headers_in.passwd.len + 1);


### PR DESCRIPTION
This updates the Basic-auth password handling to avoid relying on unchecked `len + 1` arithmetic before allocating the password buffer.

The previous version of this PR used a hard-coded 1024-byte password limit. That was not ideal because it imposed an arbitrary authentication policy limit and could reject otherwise valid inputs.

This revision instead only guards the allocation-size arithmetic itself. The password buffer is still allocated from the nginx request pool based on the actual header length, so normal nginx/request-size limits continue to govern accepted input size.

This is a defensive hardening change rather than a claim of a currently exploitable stack overflow.

## Changes
- `ngx_http_auth_spnego_module.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] Code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*