### PR TITLE
Add GSSAPI channel binding support

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,7 +34,7 @@ jobs:
             slapd ldap-utils                                                  \
             krb5-admin-server krb5-kdc krb5-kdc-ldap                          \
             libsasl2-modules-gssapi-mit                                       \
-            php-fpm php-ldap
+            php-fpm php-ldap openssl
 
       - name: Check out repository code
         uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -135,6 +135,42 @@ These options affect the operation of basic authentication:
   if one was specified by the client.
 
 
+Channel Bindings
+----------------
+
+The `auth_gss_channel_binding` directive binds a Kerberos authentication
+exchange to the TLS session it travels over, preventing a man-in-the-middle
+attack where a valid Negotiate token is relayed to a different server. The
+directive requires TLS; configuring it on a plain HTTP connection will cause
+authentication to fail.
+
+    auth_gss_channel_binding off;              # default – existing behaviour
+    auth_gss_channel_binding server-end-point; # RFC 5929 – hash of server cert
+    auth_gss_channel_binding exporter;         # RFC 9266 – TLS keying material (tech demo)
+
+**`server-end-point`** ([RFC5929](https://www.rfc-editor.org/rfc/rfc5929.html))
+hashes the server's TLS certificate. This is the only type supported by
+mainstream clients (see the table below).
+
+**`exporter`** ([RFC9266](https://www.rfc-editor.org/rfc/rfc9266.html)) derives
+32 bytes from the TLS keying material. This type is provided for
+experimentation only; do not use it in production.
+
+### Client support
+
+| Client          | Support | Notes |
+|-----------------|---------|-------|
+| curl            | **Yes** | curl ≥ 8.10.0 with OpenSSL (see [curl PR #13098](https://github.com/curl/curl/pull/13098)) and MIT Kerberos ≥ 1.19. |
+| Firefox (Linux) | **No**  | See [Mozilla bug #563276](https://bugzilla.mozilla.org/show_bug.cgi?id=563276) |
+| Chrome (Linux)  | **No**  | See the reference to `GSS_C_NO_CHANNEL_BINDINGS` in [the source](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/net/http/http_auth_gssapi_posix.cc). |
+| Windows clients | **Yes** | IE, Edge, Chrome, Firefox, etc support this automatically via [SSPI](https://en.wikipedia.org/wiki/Security_Support_Provider_Interface). |
+
+Because Firefox and Chrome on Linux do not support channel bindings, setting
+`auth_gss_channel_binding server-end-point` will cause those browsers to fail.
+Restrict this directive to deployments where all clients are known to have
+proper support for channel bindings.
+
+
 Troubleshooting
 ---------------
 

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -32,13 +32,27 @@
 #include <ngx_http.h>
 
 #include <gssapi/gssapi.h>
+#include <gssapi/gssapi_ext.h>
 #include <gssapi/gssapi_krb5.h>
 #include <krb5.h>
 #include <stdbool.h>
 
+#if (NGX_HTTP_SSL)
+#include <ngx_event_openssl.h>
+#include <openssl/evp.h>
+#include <openssl/objects.h>
+#include <openssl/x509.h>
+#endif
+
 #define CCACHE_VARIABLE_NAME "krb5_cc_name"
 #define SHM_ZONE_NAME "shm_zone"
 #define RENEWAL_TIME 60
+
+/* Values for the auth_gss_channel_binding directive. */
+#define NGX_HTTP_AUTH_SPNEGO_CB_OFF       0
+#define NGX_HTTP_AUTH_SPNEGO_CB_SERVER_EP 1
+#define NGX_HTTP_AUTH_SPNEGO_CB_EXPORTER  2
+
 
 #define spnego_log_krb5_error(context, code)                                   \
     {                                                                          \
@@ -138,6 +152,7 @@ typedef struct {
     ngx_flag_t map_to_local;
     ngx_flag_t delegate_credentials;
     ngx_flag_t constrained_delegation;
+    ngx_uint_t channel_binding;       /* NGX_HTTP_AUTH_SPNEGO_CB_* */
 } ngx_http_auth_spnego_loc_conf_t;
 
 static void ngx_http_auth_spnego_strip_realm(ngx_http_request_t *,
@@ -146,6 +161,15 @@ static void ngx_http_auth_spnego_strip_realm(ngx_http_request_t *,
 #define SPNEGO_NGX_CONF_FLAGS                                                  \
     NGX_HTTP_MAIN_CONF                                                         \
     | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_FLAG
+
+static const ngx_conf_enum_t ngx_http_auth_spnego_cb[] = {
+    { ngx_string("off"),              NGX_HTTP_AUTH_SPNEGO_CB_OFF },
+#if (NGX_HTTP_SSL)
+    { ngx_string("server-end-point"), NGX_HTTP_AUTH_SPNEGO_CB_SERVER_EP },
+    { ngx_string("exporter"),         NGX_HTTP_AUTH_SPNEGO_CB_EXPORTER },
+#endif
+    { ngx_null_string, 0 }
+};
 
 /* Module Directives */
 static ngx_command_t ngx_http_auth_spnego_commands[] = {
@@ -206,6 +230,13 @@ static ngx_command_t ngx_http_auth_spnego_commands[] = {
     {ngx_string("auth_gss_constrained_delegation"), SPNEGO_NGX_CONF_FLAGS,
      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
      offsetof(ngx_http_auth_spnego_loc_conf_t, constrained_delegation), NULL},
+
+    {ngx_string("auth_gss_channel_binding"),
+     NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF
+         | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_enum_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_auth_spnego_loc_conf_t, channel_binding),
+     (void *) &ngx_http_auth_spnego_cb},
 
     ngx_null_command};
 
@@ -309,6 +340,7 @@ static void *ngx_http_auth_spnego_create_loc_conf(ngx_conf_t *cf) {
     conf->map_to_local = NGX_CONF_UNSET;
     conf->delegate_credentials = NGX_CONF_UNSET;
     conf->constrained_delegation = NGX_CONF_UNSET;
+    conf->channel_binding = NGX_CONF_UNSET_UINT;
 
     return conf;
 }
@@ -404,6 +436,9 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
                              prev->delegate_credentials, 0);
     ngx_conf_merge_off_value(conf->constrained_delegation,
                              prev->constrained_delegation, 0);
+    ngx_conf_merge_uint_value(conf->channel_binding,
+                              prev->channel_binding,
+                              NGX_HTTP_AUTH_SPNEGO_CB_OFF);
 
 #if (NGX_DEBUG)
     ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0, "auth_spnego: protect = %i",
@@ -457,6 +492,9 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
     ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0,
                        "auth_spnego: constrained_delegation = %i",
                        conf->constrained_delegation);
+    ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0,
+                       "auth_spnego: channel_binding = %ui",
+                       conf->channel_binding);
 #endif
 
     return NGX_CONF_OK;
@@ -1515,13 +1553,118 @@ done:
     return kerr ? NGX_ERROR : NGX_OK;
 }
 
+#if (NGX_HTTP_SSL)
+/*
+ * Build a gss_channel_bindings_t for the selected channel binding type.
+ *
+ * Returns GSS_C_NO_CHANNEL_BINDINGS on error; to be treated as a hard failure.
+ */
+static gss_channel_bindings_t
+ngx_http_auth_spnego_build_channel_binding(ngx_http_request_t *r,
+                                            ngx_uint_t type)
+{
+    SSL                    *ssl = r->connection->ssl->connection;
+    gss_channel_bindings_t  cb;
+    unsigned char          *app_data;
+    size_t                  app_data_len;
+
+    if (type == NGX_HTTP_AUTH_SPNEGO_CB_EXPORTER) {
+        static const char  prefix[] = "tls-exporter:";
+        unsigned char      exported[32];
+
+        if (SSL_export_keying_material(ssl, exported, sizeof(exported),
+                                       "EXPORTER-Channel-Binding",
+                                       sizeof("EXPORTER-Channel-Binding") - 1,
+                                       NULL, 0, 1) != 1) {
+            spnego_log_error("SSL_export_keying_material() failed");
+            return GSS_C_NO_CHANNEL_BINDINGS;
+        }
+
+        app_data_len = (sizeof(prefix) - 1) + sizeof(exported);
+        app_data     = ngx_palloc(r->pool, app_data_len);
+        if (app_data == NULL)
+            return GSS_C_NO_CHANNEL_BINDINGS;
+
+        u_char *p = ngx_cpymem(app_data, prefix, sizeof(prefix) - 1);
+        ngx_cpymem(p, exported, sizeof(exported));
+
+    } else if (type == NGX_HTTP_AUTH_SPNEGO_CB_SERVER_EP) {
+        static const char  prefix[]    = "tls-server-end-point:";
+        X509              *cert;
+        const EVP_MD      *md;
+        EVP_MD_CTX        *mdctx;
+        unsigned char     *der, *der_p;
+        unsigned char      hash[EVP_MAX_MD_SIZE];
+        unsigned int       hash_len;
+        int                der_len, sig_hash_nid;
+
+        cert = SSL_get_certificate(ssl);
+        if (cert == NULL)
+            return GSS_C_NO_CHANNEL_BINDINGS;
+
+        /* RFC 5929 §4: use cert's sig-hash unless it's MD5/SHA-1 */
+        md = EVP_sha256();
+        if (OBJ_find_sigid_algs(X509_get_signature_nid(cert),
+                                &sig_hash_nid, NULL)
+            && sig_hash_nid != NID_md5 && sig_hash_nid != NID_sha1)
+        {
+            const EVP_MD *candidate = EVP_get_digestbynid(sig_hash_nid);
+            if (candidate != NULL)
+                md = candidate;
+        }
+
+        der_len = i2d_X509(cert, NULL);
+        if (der_len <= 0)
+            return GSS_C_NO_CHANNEL_BINDINGS;
+
+        der = der_p = ngx_palloc(r->pool, der_len);
+        if (der == NULL)
+            return GSS_C_NO_CHANNEL_BINDINGS;
+        i2d_X509(cert, &der_p);
+
+        mdctx = EVP_MD_CTX_new();
+        if (mdctx == NULL)
+            return GSS_C_NO_CHANNEL_BINDINGS;
+        if (EVP_DigestInit_ex(mdctx, md, NULL) != 1 ||
+            EVP_DigestUpdate(mdctx, der, der_len) != 1 ||
+            EVP_DigestFinal_ex(mdctx, hash, &hash_len) != 1) {
+            spnego_log_error("EVP digest failed computing "
+                             "tls-server-end-point channel binding");
+            EVP_MD_CTX_free(mdctx);
+            return GSS_C_NO_CHANNEL_BINDINGS;
+        }
+        EVP_MD_CTX_free(mdctx);
+
+        app_data_len = (sizeof(prefix) - 1) + hash_len;
+        app_data     = ngx_palloc(r->pool, app_data_len);
+        if (app_data == NULL)
+            return GSS_C_NO_CHANNEL_BINDINGS;
+
+        u_char *p = ngx_cpymem(app_data, prefix, sizeof(prefix) - 1);
+        ngx_cpymem(p, hash, hash_len);
+
+    } else {
+        return GSS_C_NO_CHANNEL_BINDINGS;
+    }
+
+    cb = ngx_pcalloc(r->pool, sizeof(struct gss_channel_bindings_struct));
+    if (cb == NULL)
+        return GSS_C_NO_CHANNEL_BINDINGS;
+
+    cb->application_data.length = app_data_len;
+    cb->application_data.value  = app_data;
+
+    return cb;
+}
+#endif /* NGX_HTTP_SSL */
+
 ngx_int_t
 ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
                                    ngx_http_auth_spnego_ctx_t *ctx,
                                    ngx_http_auth_spnego_loc_conf_t *alcf) {
     ngx_int_t ret = NGX_DECLINED;
     ngx_str_t spnego_token = ngx_null_string;
-    OM_uint32 major_status, minor_status, minor_status2;
+    OM_uint32 major_status, minor_status, minor_status2, ret_flags;
     gss_buffer_desc service = GSS_C_EMPTY_BUFFER;
     gss_name_t my_gss_name = GSS_C_NO_NAME;
 
@@ -1532,6 +1675,7 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
     gss_ctx_id_t gss_context = GSS_C_NO_CONTEXT;
     gss_name_t client_name = GSS_C_NO_NAME;
     gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
+    gss_channel_bindings_t cb;
 
     if (NULL == ctx || ctx->token.len == 0)
         return ret;
@@ -1610,10 +1754,27 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
     input_token.length = ctx->token.len;
     input_token.value = (void *)ctx->token.data;
 
+    cb = GSS_C_NO_CHANNEL_BINDINGS;
+    if (alcf->channel_binding != NGX_HTTP_AUTH_SPNEGO_CB_OFF) {
+#if (NGX_HTTP_SSL)
+        if (r->connection->ssl == NULL) {
+            spnego_log_error("auth_gss_channel_binding configured but "
+                             "connection is not via TLS");
+            spnego_error(NGX_ERROR);
+        }
+        cb = ngx_http_auth_spnego_build_channel_binding(r, alcf->channel_binding);
+        if (cb == GSS_C_NO_CHANNEL_BINDINGS) {
+            spnego_log_error("failed to build channel binding");
+            spnego_error(NGX_ERROR);
+        }
+#endif
+    }
+
     major_status = gss_accept_sec_context(
         &minor_status, &gss_context, my_gss_creds, &input_token,
-        GSS_C_NO_CHANNEL_BINDINGS, &client_name, NULL, &output_token, NULL,
-        NULL, &delegated_creds);
+        cb, &client_name, NULL, &output_token,
+        &ret_flags, NULL, &delegated_creds);
+
     if (GSS_ERROR(major_status)) {
         spnego_debug1("%s", get_gss_error(r->pool, minor_status,
                                           "gss_accept_sec_context() failed"));
@@ -1622,6 +1783,12 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
 
     if (major_status & GSS_S_CONTINUE_NEEDED) {
         spnego_debug0("only one authentication iteration allowed");
+        spnego_error(NGX_DECLINED);
+    }
+
+    if (alcf->channel_binding != NGX_HTTP_AUTH_SPNEGO_CB_OFF
+        && !(ret_flags & GSS_C_CHANNEL_BOUND_FLAG)) {
+        spnego_log_error("channel binding required but not provided by client");
         spnego_error(NGX_DECLINED);
     }
 

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -18,6 +18,9 @@ EX=0
 CURL_OUTPUT="http_body"
 CURL_NONEGOTIATE="curl --max-time 60 --silent --fail-with-body -o ${CURL_OUTPUT}"
 CURL_NEGOTIATE="${CURL_NONEGOTIATE} --negotiate -u :"
+CURL_HTTPS_NONEGOTIATE="${CURL_NONEGOTIATE} --insecure"
+CURL_HTTPS_NEGOTIATE="${CURL_NEGOTIATE} --insecure"
+HTTPS_PORT="8443"
 DOMAIN="example.com"
 TEST_HOST="server"
 TEST_HOST_FQDN="${TEST_HOST}.${DOMAIN}"
@@ -384,6 +387,16 @@ fi
 echo "OK"
 
 
+printf "Generating self-signed TLS certificate for channel binding tests ... "
+mkdir -p /etc/nginx/ssl || die
+openssl req -x509 -nodes -newkey rsa:2048 \
+	-keyout /etc/nginx/ssl/cb_test.key \
+	-out /etc/nginx/ssl/cb_test.crt \
+	-days 365 \
+	-subj "/CN=${TEST_HOST_FQDN}" > /dev/null 2>&1 || die
+echo "OK"
+
+
 printf "Creating nginx test site ... "
 if ! cat <<EOF > /etc/nginx/sites-available/kerberos
 # SPNEGO/Kerberos server test configuration
@@ -450,6 +463,75 @@ server {
                 auth_gss_delegate_credentials on;
                 auth_gss_constrained_delegation on;
 	}
+
+	# Channel binding directive on plain HTTP: no TLS session exists so the
+	# module fails with a 500 error.
+	location /cbinding_sep.php {
+		include snippets/fastcgi-php.conf;
+		fastcgi_pass unix:/run/php/php-fpm.sock;
+                auth_gss on;
+                auth_gss_realm ${KERBEROS_REALM};
+                auth_gss_keytab /etc/krb5.http.keytab;
+                auth_gss_service_name HTTP/${TEST_HOST_FQDN};
+                auth_gss_allow_basic_fallback off;
+                auth_gss_authorized_principal alice@${KERBEROS_REALM};
+                auth_gss_format_full on;
+                fastcgi_param HTTP_AUTHORIZATION "";
+                auth_gss_channel_binding server-end-point;
+	}
+}
+
+# HTTPS server for channel binding tests.
+server {
+	listen ${HTTPS_PORT} ssl;
+	listen [::]:${HTTPS_PORT} ssl;
+
+	ssl_certificate     /etc/nginx/ssl/cb_test.crt;
+	ssl_certificate_key /etc/nginx/ssl/cb_test.key;
+	ssl_protocols       TLSv1.2 TLSv1.3;
+
+	root /var/www/kerberos;
+
+	server_name ${TEST_HOST_FQDN};
+
+	# Sanity check: plain HTTPS connectivity, no auth.
+	location /noauth.php {
+		include snippets/fastcgi-php.conf;
+		fastcgi_pass unix:/run/php/php-fpm.sock;
+		auth_gss off;
+	}
+
+	# RFC 5929 tls-server-end-point binding: clients must send matching
+	# channel binding or are rejected with 403.
+	location /cbinding_sep.php {
+		include snippets/fastcgi-php.conf;
+		fastcgi_pass unix:/run/php/php-fpm.sock;
+                auth_gss on;
+                auth_gss_realm ${KERBEROS_REALM};
+                auth_gss_keytab /etc/krb5.http.keytab;
+                auth_gss_service_name HTTP/${TEST_HOST_FQDN};
+                auth_gss_allow_basic_fallback off;
+                auth_gss_authorized_principal alice@${KERBEROS_REALM};
+                auth_gss_format_full on;
+                fastcgi_param HTTP_AUTHORIZATION "";
+                auth_gss_channel_binding server-end-point;
+	}
+
+	# RFC 9266 tls-exporter binding: no mainstream client supports this
+	# for HTTP Negotiate, so all authenticated requests are rejected with 403.
+	location /cbinding_exp.php {
+		include snippets/fastcgi-php.conf;
+		fastcgi_pass unix:/run/php/php-fpm.sock;
+                auth_gss on;
+                auth_gss_realm ${KERBEROS_REALM};
+                auth_gss_keytab /etc/krb5.http.keytab;
+                auth_gss_service_name HTTP/${TEST_HOST_FQDN};
+                auth_gss_allow_basic_fallback off;
+                auth_gss_authorized_principal alice@${KERBEROS_REALM};
+                auth_gss_format_full on;
+                fastcgi_param HTTP_AUTHORIZATION "";
+                auth_gss_channel_binding exporter;
+	}
 }
 EOF
 then
@@ -503,6 +585,24 @@ EOF
 then
 	die
 fi
+echo "OK"
+
+
+printf "Writing cbinding_sep.php and cbinding_exp.php ... "
+if ! cat <<'EOF' > /var/www/kerberos/cbinding_sep.php
+<?php
+	if (!isset($_SERVER["REMOTE_USER"]) || $_SERVER["REMOTE_USER"] == "") {
+		http_response_code(500);
+		echo("REMOTE_USER not set");
+		exit();
+	}
+	echo("Authenticated as " . $_SERVER["REMOTE_USER"]);
+?>
+EOF
+then
+	die
+fi
+cp /var/www/kerberos/cbinding_sep.php /var/www/kerberos/cbinding_exp.php || die
 echo "OK"
 
 
@@ -656,6 +756,59 @@ test_basic()
 
 }
 
+test_https_path()
+{
+	SUBURL="$1"
+	EXPECT1="$2"
+	EXPECT2="$3"
+
+	printf "curl https://%s:%s/%s, no negotiate: http status (expect %s)=" \
+		"${TEST_HOST_FQDN}" "${HTTPS_PORT}" "${SUBURL}" "${EXPECT1}"
+	rm -f "${CURL_OUTPUT}"
+	CODE="$($CURL_HTTPS_NONEGOTIATE -w "%{http_code}" \
+		"https://${TEST_HOST_FQDN}:${HTTPS_PORT}/${SUBURL}")" || true
+	printf "%s ... " "${CODE}"
+	if [ "$CODE" = "${EXPECT1}" ]; then
+		echo "OK"
+	else
+		EX=1
+		echo "FAILED"
+		if [ -e "${CURL_OUTPUT}" ]; then
+			echo "HTTP body:"
+			cat "${CURL_OUTPUT}"
+			echo ""
+		fi
+	fi
+
+	printf "curl https://%s:%s/%s, negotiate: http status (expect %s)=" \
+		"${TEST_HOST_FQDN}" "${HTTPS_PORT}" "${SUBURL}" "${EXPECT2}"
+	rm -f "${CURL_OUTPUT}"
+	CODE="$($CURL_HTTPS_NEGOTIATE -w "%{http_code}" \
+		"https://${TEST_HOST_FQDN}:${HTTPS_PORT}/${SUBURL}")" || true
+	printf "%s ... " "${CODE}"
+	if [ "$CODE" = "${EXPECT2}" ]; then
+		echo "OK"
+	else
+		EX=1
+		echo "FAILED"
+		if [ -e "${CURL_OUTPUT}" ]; then
+			echo "HTTP body:"
+			cat "${CURL_OUTPUT}"
+			echo ""
+		fi
+	fi
+}
+
+curl_supports_channel_binding()
+{
+	curl --version | grep -q OpenSSL || return 1
+	set -- $(curl --version | head -1 | awk '{print $2}' | tr '.' ' ')
+	CMAJ="${1:-0}" CMIN="${2:-0}"
+	[ "${CMAJ}" -gt 8 ] && return 0
+	[ "${CMAJ}" -eq 8 ] && [ "${CMIN}" -ge 10 ] && return 0
+	return 1
+}
+
 test_ldapwhoami()
 {
 	LDAP_EXPECTED="dn:uid=${1},cn=gss-spnego,cn=auth"
@@ -803,6 +956,84 @@ else
 fi
 test_path "delegate.php" 401 200
 test_ldapwhoami "alice"
+
+
+echo ""
+echo "=== Channel binding tests ==="
+echo ""
+
+printf "Destroying Kerberos tickets ... "
+kdestroy -q > /dev/null 2>&1 || true
+echo "OK"
+
+# Plain HTTP + auth_gss_channel_binding server-end-point: no TLS session
+# exists so the module fails with a 500 error.
+echo ""
+echo "--- Channel binding directive on plain HTTP (expect 401/500) ---"
+test_path "cbinding_sep.php" 401 401
+
+printf "Obtaining Kerberos ticket for alice ... "
+if kinit -kt krb5.alice.keytab alice; then
+	echo "OK"
+else
+	EX=1
+	echo "FAILED"
+fi
+test_path "cbinding_sep.php" 401 500
+
+# HTTPS sanity: verify the TLS server is reachable before the CB tests.
+echo ""
+echo "--- HTTPS connectivity sanity check ---"
+test_https_path "noauth.php" 200 200
+
+echo ""
+echo "--- HTTPS + auth_gss_channel_binding server-end-point ---"
+if curl_supports_channel_binding; then
+	echo "    curl supports tls-server-end-point (curl >= 8.10.0 + OpenSSL)"
+	# Unauthenticated: 401 challenge.
+	# Authenticated with matching channel binding: 200.
+	test_https_path "cbinding_sep.php" 401 200
+
+	printf "Destroying Kerberos tickets ... "
+	kdestroy -q > /dev/null 2>&1 || true
+	echo "OK"
+
+	# No ticket: both unauthenticated and negotiate return 401.
+	test_https_path "cbinding_sep.php" 401 401
+else
+	echo "    curl does not support tls-server-end-point"
+	echo "    (requires curl >= 8.10.0 built against OpenSSL;"
+	echo "     see https://github.com/curl/curl/pull/13098)"
+	# Unauthenticated: 401 challenge.
+	# Authenticated without a channel binding: GSS_C_CHANNEL_BOUND_FLAG not
+	# set, rejected with 403 (allow_basic_fallback is off).
+	test_https_path "cbinding_sep.php" 401 403
+fi
+
+echo ""
+echo "--- HTTPS + auth_gss_channel_binding exporter (always 401/403) ---"
+echo "    No mainstream client sends tls-exporter channel binding for HTTP Negotiate."
+# Re-obtain ticket if it was destroyed above.
+if ! klist -s > /dev/null 2>&1; then
+	printf "Obtaining Kerberos ticket for alice ... "
+	if kinit -kt krb5.alice.keytab alice; then
+		echo "OK"
+	else
+		EX=1
+		echo "FAILED"
+	fi
+fi
+# Unauthenticated: 401 challenge.
+# Authenticated: GSS_C_CHANNEL_BOUND_FLAG never set (no client sends
+# tls-exporter); rejected with 403.
+test_https_path "cbinding_exp.php" 401 403
+
+printf "Destroying Kerberos tickets ... "
+kdestroy -q > /dev/null 2>&1 || true
+echo "OK"
+
+# No ticket: both unauthenticated and negotiate return 401.
+test_https_path "cbinding_exp.php" 401 401
 
 
 echo ""


### PR DESCRIPTION
GSSAPI channel binding ties application-layer authentication (like Kerberos or NTLM) to the underlying secure network transport layer (typically by binding to a hash of the server SSL/TLS cert), which blocks some man-in-the-middle and relay attacks.

This adds server-end-point (RFC 5929) and exporter (RFC 9266) binding types (the latter being more of a tech demo since it has no current mainstream client support).

Most deployments should (sadly) leave bindings off for now since mainstream Linux browsers do not support them (which is why "off" is the default).