### PR TITLE
Fix satisfy any stripping mutual-auth WWW-Authenticate token

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ config file.
 
     auth_gss_allow_basic_fallback off
 
+SPNEGO mutual authentication with `satisfy any`
+-------------------------------------------------
+
+nginx clears `WWW-Authenticate` on successful auth when `satisfy any` is
+enabled, which breaks SPNEGO mutual authentication (the server token must be
+returned on the final 2xx response). See [nginx#861](https://github.com/nginx/nginx/issues/861).
+
+This module registers an output header filter (enabled by default) to restore
+the mutual-auth token when nginx strips it:
+
+    auth_gss_preserve_mutual_auth on;   # default
+    auth_gss_preserve_mutual_auth off;  # disable if nginx is patched
+
+This workaround does not fix combining `auth_basic` and `auth_gss` under
+`satisfy any` when Basic auth fails after SPNEGO succeeds (final 401). Avoid
+using both in the same `satisfy any` context for mutual auth.
+
 These options affect the operation of basic authentication:
 * `auth_gss_realm`: Kerberos realm name.  If this is specified, the realm is
   only passed to the nginx variable $remote_user if it differs from this

--- a/README.md
+++ b/README.md
@@ -130,20 +130,14 @@ nginx clears `WWW-Authenticate` on successful auth when `satisfy any` is
 enabled, which breaks SPNEGO mutual authentication (the server token must be
 returned on the final 2xx response). See [nginx#861](https://github.com/nginx/nginx/issues/861).
 
-This module registers an output header filter (enabled by default) to restore
-the mutual-auth token when nginx strips it:
+On success, the module stores the GSS output token and adds
+`WWW-Authenticate: Negotiate <token>` in an output header filter, which runs
+after nginx's satisfy-any cleanup. Challenge headers for 401 responses are still
+set in the access handler.
 
-    auth_gss_preserve_mutual_auth on;   # default
-    auth_gss_preserve_mutual_auth off;  # disable if nginx is patched
-
-This workaround does not fix combining `auth_basic` and `auth_gss` under
-`satisfy any` when Basic auth fails after SPNEGO succeeds (final 401). Avoid
-using both in the same `satisfy any` context for mutual auth.
-
-The `return` directive is evaluated in the rewrite phase before the access
-phase, so `auth_gss` does not run for `return 200 "body"` in the same location.
-Serve content via `alias`, `root`, or a proxied upstream after authentication
-instead.
+Combining `auth_basic` and `auth_gss` under `satisfy any` when Basic auth fails
+after SPNEGO succeeds can still yield a final 401 without the mutual-auth token.
+Avoid using both in the same `satisfy any` context for mutual auth.
 
 These options affect the operation of basic authentication:
 * `auth_gss_realm`: Kerberos realm name.  If this is specified, the realm is

--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ This workaround does not fix combining `auth_basic` and `auth_gss` under
 `satisfy any` when Basic auth fails after SPNEGO succeeds (final 401). Avoid
 using both in the same `satisfy any` context for mutual auth.
 
+The `return` directive is evaluated in the rewrite phase before the access
+phase, so `auth_gss` does not run for `return 200 "body"` in the same location.
+Serve content via `alias`, `root`, or a proxied upstream after authentication
+instead.
+
 These options affect the operation of basic authentication:
 * `auth_gss_realm`: Kerberos realm name.  If this is specified, the realm is
   only passed to the nginx variable $remote_user if it differs from this

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -121,6 +121,9 @@ typedef struct {
     ngx_str_t token_out_b64; /* base64 encoded output tokent */
 } ngx_http_auth_spnego_ctx_t;
 
+static ngx_http_auth_spnego_ctx_t *
+ngx_http_auth_spnego_get_ctx(ngx_http_request_t *r);
+
 typedef struct {
     ngx_flag_t protect;
     ngx_str_t realm;
@@ -659,6 +662,29 @@ ngx_http_auth_spnego_mutual_token_present(ngx_http_request_t *r)
     return 0;
 }
 
+static ngx_http_auth_spnego_ctx_t *
+ngx_http_auth_spnego_get_ctx(ngx_http_request_t *r)
+{
+    ngx_http_auth_spnego_ctx_t  *ctx;
+    ngx_http_request_t          *auth_r;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_auth_spnego_module);
+    if (ctx != NULL) {
+        return ctx;
+    }
+
+    auth_r = r;
+    while (auth_r->parent) {
+        auth_r = auth_r->parent;
+    }
+
+    if (auth_r != r) {
+        return ngx_http_get_module_ctx(auth_r, ngx_http_auth_spnego_module);
+    }
+
+    return NULL;
+}
+
 static ngx_uint_t
 ngx_http_auth_spnego_is_negotiate_mutual_value(ngx_str_t *value)
 {
@@ -739,10 +765,8 @@ ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r)
         return NGX_DECLINED;
     }
 
-    ctx = ngx_http_get_module_ctx(r, ngx_http_auth_spnego_module);
+    ctx = ngx_http_auth_spnego_get_ctx(r);
     if (ctx == NULL || ctx->token_out_b64.len == 0) {
-        spnego_log_error("spnego preserve: skip (ctx=%p token_out_b64.len=%uz)",
-                         ctx, ctx ? ctx->token_out_b64.len : 0);
         return NGX_DECLINED;
     }
 
@@ -1871,10 +1895,6 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
         ctx->token_out_b64.len = 0;
         ctx->token_out_b64.data = NULL;
     }
-
-    spnego_log_error("spnego auth: token_out_b64.len=%uz ret_flags=0%uxD major=0%uxD",
-                     ctx->token_out_b64.len, (uint32_t) ret_flags,
-                     (uint32_t) major_status);
 
     /* getting user name at the other end of the request */
     major_status =

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -741,6 +741,8 @@ ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r)
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_auth_spnego_module);
     if (ctx == NULL || ctx->token_out_b64.len == 0) {
+        spnego_log_error("spnego preserve: skip (ctx=%p token_out_b64.len=%uz)",
+                         ctx, ctx ? ctx->token_out_b64.len : 0);
         return NGX_DECLINED;
     }
 
@@ -1869,6 +1871,10 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
         ctx->token_out_b64.len = 0;
         ctx->token_out_b64.data = NULL;
     }
+
+    spnego_log_error("spnego auth: token_out_b64.len=%uz ret_flags=0%uxD major=0%uxD",
+                     ctx->token_out_b64.len, (uint32_t) ret_flags,
+                     (uint32_t) major_status);
 
     /* getting user name at the other end of the request */
     major_status =

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -1694,12 +1694,42 @@ done:
     return kerr ? NGX_ERROR : NGX_OK;
 }
 
+static ngx_int_t
+ngx_http_auth_spnego_store_output_token(ngx_http_request_t *r,
+                                        ngx_http_auth_spnego_ctx_t *ctx,
+                                        gss_buffer_desc *output_token)
+{
+    ngx_str_t  spnego_token;
+    OM_uint32  minor_status;
+
+    if (output_token->length == 0) {
+        ctx->token_out_b64.len = 0;
+        ctx->token_out_b64.data = NULL;
+        return NGX_OK;
+    }
+
+    spnego_token.data = (u_char *) output_token->value;
+    spnego_token.len = output_token->length;
+
+    ctx->token_out_b64.len = ngx_base64_encoded_length(spnego_token.len);
+    ctx->token_out_b64.data = ngx_pcalloc(r->pool, ctx->token_out_b64.len + 1);
+    if (ctx->token_out_b64.data == NULL) {
+        spnego_log_error("Not enough memory");
+        gss_release_buffer(&minor_status, output_token);
+        return NGX_ERROR;
+    }
+
+    ngx_encode_base64(&ctx->token_out_b64, &spnego_token);
+    gss_release_buffer(&minor_status, output_token);
+
+    return NGX_OK;
+}
+
 ngx_int_t
 ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
                                    ngx_http_auth_spnego_ctx_t *ctx,
                                    ngx_http_auth_spnego_loc_conf_t *alcf) {
     ngx_int_t ret = NGX_DECLINED;
-    ngx_str_t spnego_token = ngx_null_string;
     OM_uint32 major_status, minor_status, minor_status2;
     gss_buffer_desc service = GSS_C_EMPTY_BUFFER;
     gss_name_t my_gss_name = GSS_C_NO_NAME;
@@ -1711,6 +1741,8 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
     gss_ctx_id_t gss_context = GSS_C_NO_CONTEXT;
     gss_name_t client_name = GSS_C_NO_NAME;
     gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
+    gss_buffer_desc empty_token = GSS_C_EMPTY_BUFFER;
+    OM_uint32       ret_flags = 0;
 
     if (NULL == ctx || ctx->token.len == 0)
         return ret;
@@ -1791,8 +1823,8 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
 
     major_status = gss_accept_sec_context(
         &minor_status, &gss_context, my_gss_creds, &input_token,
-        GSS_C_NO_CHANNEL_BINDINGS, &client_name, NULL, &output_token, NULL,
-        NULL, &delegated_creds);
+        GSS_C_NO_CHANNEL_BINDINGS, &client_name, NULL, &output_token,
+        &ret_flags, NULL, &delegated_creds);
     if (GSS_ERROR(major_status)) {
         spnego_debug1("%s", get_gss_error(r->pool, minor_status,
                                           "gss_accept_sec_context() failed"));
@@ -1800,26 +1832,42 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
     }
 
     if (major_status & GSS_S_CONTINUE_NEEDED) {
-        spnego_debug0("only one authentication iteration allowed");
-        spnego_error(NGX_DECLINED);
-    }
+        if (output_token.length == 0) {
+            spnego_debug0("GSS continue needed without output token");
+            spnego_error(NGX_DECLINED);
+        }
 
-    if (output_token.length) {
-        spnego_token.data = (u_char *)output_token.value;
-        spnego_token.len = output_token.length;
-
-        ctx->token_out_b64.len = ngx_base64_encoded_length(spnego_token.len);
-        ctx->token_out_b64.data =
-            ngx_pcalloc(r->pool, ctx->token_out_b64.len + 1);
-        if (NULL == ctx->token_out_b64.data) {
-            spnego_log_error("Not enough memory");
-            gss_release_buffer(&minor_status2, &output_token);
+        spnego_debug0("GSS mutual authentication output token");
+        if (ngx_http_auth_spnego_store_output_token(r, ctx, &output_token) !=
+            NGX_OK) {
             spnego_error(NGX_ERROR);
         }
-        ngx_encode_base64(&ctx->token_out_b64, &spnego_token);
-        gss_release_buffer(&minor_status2, &output_token);
+
+    } else if (output_token.length) {
+        if (ngx_http_auth_spnego_store_output_token(r, ctx, &output_token) !=
+            NGX_OK) {
+            spnego_error(NGX_ERROR);
+        }
+
+    } else if (ret_flags & GSS_C_MUTUAL_FLAG) {
+        major_status = gss_accept_sec_context(
+            &minor_status, &gss_context, my_gss_creds, &empty_token,
+            GSS_C_NO_CHANNEL_BINDINGS, NULL, NULL, &output_token, NULL, NULL,
+            NULL);
+
+        if (!GSS_ERROR(major_status) && output_token.length) {
+            if (ngx_http_auth_spnego_store_output_token(r, ctx, &output_token)
+                != NGX_OK) {
+                spnego_error(NGX_ERROR);
+            }
+        } else {
+            ctx->token_out_b64.len = 0;
+            ctx->token_out_b64.data = NULL;
+        }
+
     } else {
         ctx->token_out_b64.len = 0;
+        ctx->token_out_b64.data = NULL;
     }
 
     /* getting user name at the other end of the request */
@@ -1917,6 +1965,8 @@ static ngx_int_t ngx_http_auth_spnego_handler(ngx_http_request_t *r) {
         }
         ctx->token.len = 0;
         ctx->token.data = NULL;
+        ctx->token_out_b64.len = 0;
+        ctx->token_out_b64.data = NULL;
         ctx->head = 0;
         ctx->ret = NGX_HTTP_UNAUTHORIZED;
         ngx_http_set_ctx(r, ctx, ngx_http_auth_spnego_module);

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -70,6 +70,8 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *);
 
 static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
 static ngx_int_t ngx_http_auth_spnego_header_filter(ngx_http_request_t *r);
+static ngx_int_t ngx_http_auth_spnego_post_access_preserve(ngx_http_request_t *r);
+static ngx_int_t ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r);
 
 #if (NGX_PCRE)
 static char *ngx_conf_set_regex_array_slot(ngx_conf_t *cf, ngx_command_t *cmd,
@@ -533,6 +535,13 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *cf) {
 
     *h = ngx_http_auth_spnego_handler;
 
+    h = ngx_array_push(&cmcf->phases[NGX_HTTP_POST_ACCESS_PHASE].handlers);
+    if (NULL == h) {
+        return NGX_ERROR;
+    }
+
+    *h = ngx_http_auth_spnego_post_access_preserve;
+
     ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
     if (ngx_http_auth_spnego_add_variable(cf, &var_name) != NGX_OK) {
         return NGX_ERROR;
@@ -554,9 +563,7 @@ ngx_http_auth_spnego_add_www_authenticate(ngx_http_request_t *r,
     }
 
     h->hash = hash;
-#if defined(nginx_version) && nginx_version >= 1023000
-    h->next = NULL;
-#endif
+    h->next = r->headers_out.www_authenticate;
     h->key.len = sizeof("WWW-Authenticate") - 1;
     h->key.data = (u_char *)"WWW-Authenticate";
     h->value = *value;
@@ -651,38 +658,63 @@ ngx_http_auth_spnego_mutual_token_present(ngx_http_request_t *r)
     return 0;
 }
 
+/*
+ * nginx satisfy any clears WWW-Authenticate by setting hash=0 while leaving
+ * the header value intact; restore hash so the mutual-auth token is sent.
+ */
+static ngx_uint_t
+ngx_http_auth_spnego_restore_mutual_auth_headers(ngx_http_request_t *r)
+{
+    ngx_table_elt_t  *h;
+    size_t            prefix;
+    ngx_uint_t        restored;
+
+    prefix = sizeof("Negotiate ") - 1;
+    restored = 0;
+
+    for (h = r->headers_out.www_authenticate; h; h = h->next) {
+        if (h->hash != 0 || h->value.len <= prefix) {
+            continue;
+        }
+
+        if (ngx_strncmp(h->value.data, "Negotiate ", prefix) == 0) {
+            h->hash = 1;
+            restored = 1;
+        }
+    }
+
+    return restored;
+}
+
 static ngx_int_t
-ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
+ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r)
 {
     ngx_http_auth_spnego_ctx_t       *ctx;
     ngx_http_auth_spnego_loc_conf_t  *alcf;
     ngx_str_t                         value;
 
-    if (r != r->main) {
-        return ngx_http_next_header_filter(r);
-    }
-
     alcf = ngx_http_get_module_loc_conf(r, ngx_http_auth_spnego_module);
     if (alcf == NULL || alcf->protect == 0 || alcf->preserve_mutual_auth == 0) {
-        return ngx_http_next_header_filter(r);
+        return NGX_DECLINED;
     }
 
-    /* status may still be 0 here for a 200 from return/content; only skip
-     * explicit non-2xx responses */
+    /* status may still be 0 for return/content; only skip explicit non-2xx */
     if (r->headers_out.status != 0
         && (r->headers_out.status < NGX_HTTP_OK
             || r->headers_out.status >= NGX_HTTP_SPECIAL_RESPONSE))
     {
-        return ngx_http_next_header_filter(r);
+        return NGX_DECLINED;
+    }
+
+    (void) ngx_http_auth_spnego_restore_mutual_auth_headers(r);
+
+    if (ngx_http_auth_spnego_mutual_token_present(r)) {
+        return NGX_DECLINED;
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_auth_spnego_module);
-    if (ctx == NULL || ctx->ret != NGX_OK || ctx->token_out_b64.len == 0) {
-        return ngx_http_next_header_filter(r);
-    }
-
-    if (ngx_http_auth_spnego_mutual_token_present(r)) {
-        return ngx_http_next_header_filter(r);
+    if (ctx == NULL || ctx->token_out_b64.len == 0) {
+        return NGX_DECLINED;
     }
 
     value.len = sizeof("Negotiate ") - 1 + ctx->token_out_b64.len;
@@ -694,6 +726,40 @@ ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
     ngx_snprintf(value.data, value.len, "Negotiate %V", &ctx->token_out_b64);
 
     if (ngx_http_auth_spnego_add_www_authenticate(r, &value, 1) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    return NGX_DECLINED;
+}
+
+static ngx_int_t
+ngx_http_auth_spnego_post_access_preserve(ngx_http_request_t *r)
+{
+    ngx_int_t  rc;
+
+    if (r != r->main) {
+        return NGX_DECLINED;
+    }
+
+    rc = ngx_http_auth_spnego_preserve_mutual_auth(r);
+    if (rc == NGX_ERROR) {
+        return NGX_ERROR;
+    }
+
+    return NGX_DECLINED;
+}
+
+static ngx_int_t
+ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
+{
+    ngx_int_t  rc;
+
+    if (r != r->main) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    rc = ngx_http_auth_spnego_preserve_mutual_auth(r);
+    if (rc == NGX_ERROR) {
         return NGX_ERROR;
     }
 

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -70,8 +70,6 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *);
 
 static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
 static ngx_int_t ngx_http_auth_spnego_header_filter(ngx_http_request_t *r);
-static ngx_int_t ngx_http_auth_spnego_post_access_preserve(ngx_http_request_t *r);
-static ngx_int_t ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r);
 
 #if (NGX_PCRE)
 static char *ngx_conf_set_regex_array_slot(ngx_conf_t *cf, ngx_command_t *cmd,
@@ -535,13 +533,6 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *cf) {
 
     *h = ngx_http_auth_spnego_handler;
 
-    h = ngx_array_push(&cmcf->phases[NGX_HTTP_POST_ACCESS_PHASE].handlers);
-    if (NULL == h) {
-        return NGX_ERROR;
-    }
-
-    *h = ngx_http_auth_spnego_post_access_preserve;
-
     ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
     if (ngx_http_auth_spnego_add_variable(cf, &var_name) != NGX_OK) {
         return NGX_ERROR;
@@ -563,7 +554,9 @@ ngx_http_auth_spnego_add_www_authenticate(ngx_http_request_t *r,
     }
 
     h->hash = hash;
-    h->next = r->headers_out.www_authenticate;
+#if defined(nginx_version) && nginx_version >= 1023000
+    h->next = NULL;
+#endif
     h->key.len = sizeof("WWW-Authenticate") - 1;
     h->key.data = (u_char *)"WWW-Authenticate";
     h->value = *value;
@@ -658,19 +651,14 @@ ngx_http_auth_spnego_mutual_token_present(ngx_http_request_t *r)
     return 0;
 }
 
-/*
- * nginx satisfy any clears WWW-Authenticate by setting hash=0 while leaving
- * the header value intact; restore hash so the mutual-auth token is sent.
- */
-static ngx_uint_t
+/* nginx satisfy any clears WWW-Authenticate via hash=0; restore for Negotiate */
+static void
 ngx_http_auth_spnego_restore_mutual_auth_headers(ngx_http_request_t *r)
 {
     ngx_table_elt_t  *h;
     size_t            prefix;
-    ngx_uint_t        restored;
 
     prefix = sizeof("Negotiate ") - 1;
-    restored = 0;
 
     for (h = r->headers_out.www_authenticate; h; h = h->next) {
         if (h->hash != 0 || h->value.len <= prefix) {
@@ -679,42 +667,44 @@ ngx_http_auth_spnego_restore_mutual_auth_headers(ngx_http_request_t *r)
 
         if (ngx_strncmp(h->value.data, "Negotiate ", prefix) == 0) {
             h->hash = 1;
-            restored = 1;
         }
     }
-
-    return restored;
 }
 
 static ngx_int_t
-ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r)
+ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
 {
     ngx_http_auth_spnego_ctx_t       *ctx;
     ngx_http_auth_spnego_loc_conf_t  *alcf;
     ngx_str_t                         value;
 
-    alcf = ngx_http_get_module_loc_conf(r, ngx_http_auth_spnego_module);
-    if (alcf == NULL || alcf->protect == 0 || alcf->preserve_mutual_auth == 0) {
-        return NGX_DECLINED;
+    if (r != r->main) {
+        return ngx_http_next_header_filter(r);
     }
 
-    /* status may still be 0 for return/content; only skip explicit non-2xx */
+    alcf = ngx_http_get_module_loc_conf(r, ngx_http_auth_spnego_module);
+    if (alcf == NULL || alcf->protect == 0 || alcf->preserve_mutual_auth == 0) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    /* status may still be 0 here for a 200 from return/content; only skip
+     * explicit non-2xx responses */
     if (r->headers_out.status != 0
         && (r->headers_out.status < NGX_HTTP_OK
             || r->headers_out.status >= NGX_HTTP_SPECIAL_RESPONSE))
     {
-        return NGX_DECLINED;
+        return ngx_http_next_header_filter(r);
     }
 
-    (void) ngx_http_auth_spnego_restore_mutual_auth_headers(r);
+    ngx_http_auth_spnego_restore_mutual_auth_headers(r);
 
     if (ngx_http_auth_spnego_mutual_token_present(r)) {
-        return NGX_DECLINED;
+        return ngx_http_next_header_filter(r);
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_auth_spnego_module);
     if (ctx == NULL || ctx->token_out_b64.len == 0) {
-        return NGX_DECLINED;
+        return ngx_http_next_header_filter(r);
     }
 
     value.len = sizeof("Negotiate ") - 1 + ctx->token_out_b64.len;
@@ -726,40 +716,6 @@ ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r)
     ngx_snprintf(value.data, value.len, "Negotiate %V", &ctx->token_out_b64);
 
     if (ngx_http_auth_spnego_add_www_authenticate(r, &value, 1) != NGX_OK) {
-        return NGX_ERROR;
-    }
-
-    return NGX_DECLINED;
-}
-
-static ngx_int_t
-ngx_http_auth_spnego_post_access_preserve(ngx_http_request_t *r)
-{
-    ngx_int_t  rc;
-
-    if (r != r->main) {
-        return NGX_DECLINED;
-    }
-
-    rc = ngx_http_auth_spnego_preserve_mutual_auth(r);
-    if (rc == NGX_ERROR) {
-        return NGX_ERROR;
-    }
-
-    return NGX_DECLINED;
-}
-
-static ngx_int_t
-ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
-{
-    ngx_int_t  rc;
-
-    if (r != r->main) {
-        return ngx_http_next_header_filter(r);
-    }
-
-    rc = ngx_http_auth_spnego_preserve_mutual_auth(r);
-    if (rc == NGX_ERROR) {
         return NGX_ERROR;
     }
 

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -68,6 +68,9 @@ static void *ngx_http_auth_spnego_create_loc_conf(ngx_conf_t *);
 static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *, void *, void *);
 static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *);
 
+static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
+static ngx_int_t ngx_http_auth_spnego_header_filter(ngx_http_request_t *r);
+
 #if (NGX_PCRE)
 static char *ngx_conf_set_regex_array_slot(ngx_conf_t *cf, ngx_command_t *cmd,
                                            void *conf);
@@ -138,6 +141,7 @@ typedef struct {
     ngx_flag_t map_to_local;
     ngx_flag_t delegate_credentials;
     ngx_flag_t constrained_delegation;
+    ngx_flag_t preserve_mutual_auth;
 } ngx_http_auth_spnego_loc_conf_t;
 
 static void ngx_http_auth_spnego_strip_realm(ngx_http_request_t *,
@@ -206,6 +210,10 @@ static ngx_command_t ngx_http_auth_spnego_commands[] = {
     {ngx_string("auth_gss_constrained_delegation"), SPNEGO_NGX_CONF_FLAGS,
      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
      offsetof(ngx_http_auth_spnego_loc_conf_t, constrained_delegation), NULL},
+
+    {ngx_string("auth_gss_preserve_mutual_auth"), SPNEGO_NGX_CONF_FLAGS,
+     ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_auth_spnego_loc_conf_t, preserve_mutual_auth), NULL},
 
     ngx_null_command};
 
@@ -309,6 +317,7 @@ static void *ngx_http_auth_spnego_create_loc_conf(ngx_conf_t *cf) {
     conf->map_to_local = NGX_CONF_UNSET;
     conf->delegate_credentials = NGX_CONF_UNSET;
     conf->constrained_delegation = NGX_CONF_UNSET;
+    conf->preserve_mutual_auth = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -404,6 +413,8 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
                              prev->delegate_credentials, 0);
     ngx_conf_merge_off_value(conf->constrained_delegation,
                              prev->constrained_delegation, 0);
+    ngx_conf_merge_off_value(conf->preserve_mutual_auth,
+                             prev->preserve_mutual_auth, 1);
 
 #if (NGX_DEBUG)
     ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0, "auth_spnego: protect = %i",
@@ -527,6 +538,9 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *cf) {
         return NGX_ERROR;
     }
 
+    ngx_http_next_header_filter = ngx_http_top_header_filter;
+    ngx_http_top_header_filter = ngx_http_auth_spnego_header_filter;
+
     return NGX_OK;
 }
 
@@ -612,6 +626,75 @@ ngx_http_auth_spnego_headers(ngx_http_request_t *r,
 
     ctx->head = 1;
     return NGX_OK;
+}
+
+static ngx_uint_t
+ngx_http_auth_spnego_mutual_token_present(ngx_http_request_t *r)
+{
+    ngx_table_elt_t  *h;
+    size_t            prefix;
+
+    prefix = sizeof("Negotiate ") - 1;
+
+    for (h = r->headers_out.www_authenticate; h; h = h->next) {
+        if (h->hash == 0 || h->value.len <= prefix) {
+            continue;
+        }
+
+        if (ngx_strncmp(h->value.data, "Negotiate ", prefix) == 0
+            && h->value.len > prefix)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static ngx_int_t
+ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
+{
+    ngx_http_auth_spnego_ctx_t       *ctx;
+    ngx_http_auth_spnego_loc_conf_t  *alcf;
+    ngx_str_t                         value;
+
+    if (r != r->main) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    alcf = ngx_http_get_module_loc_conf(r, ngx_http_auth_spnego_module);
+    if (alcf == NULL || alcf->protect == 0 || alcf->preserve_mutual_auth == 0) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    if (r->headers_out.status < NGX_HTTP_OK
+        || r->headers_out.status >= NGX_HTTP_SPECIAL_RESPONSE)
+    {
+        return ngx_http_next_header_filter(r);
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_auth_spnego_module);
+    if (ctx == NULL || ctx->ret != NGX_OK || ctx->token_out_b64.len == 0) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    if (ngx_http_auth_spnego_mutual_token_present(r)) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    value.len = sizeof("Negotiate ") - 1 + ctx->token_out_b64.len;
+    value.data = ngx_pnalloc(r->pool, value.len);
+    if (value.data == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_snprintf(value.data, value.len, "Negotiate %V", &ctx->token_out_b64);
+
+    if (ngx_http_auth_spnego_add_www_authenticate(r, &value, 1) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    return ngx_http_next_header_filter(r);
 }
 
 static bool

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -667,8 +667,11 @@ ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
         return ngx_http_next_header_filter(r);
     }
 
-    if (r->headers_out.status < NGX_HTTP_OK
-        || r->headers_out.status >= NGX_HTTP_SPECIAL_RESPONSE)
+    /* status may still be 0 here for a 200 from return/content; only skip
+     * explicit non-2xx responses */
+    if (r->headers_out.status != 0
+        && (r->headers_out.status < NGX_HTTP_OK
+            || r->headers_out.status >= NGX_HTTP_SPECIAL_RESPONSE))
     {
         return ngx_http_next_header_filter(r);
     }

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -70,6 +70,7 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *);
 
 static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
 static ngx_int_t ngx_http_auth_spnego_header_filter(ngx_http_request_t *r);
+static ngx_int_t ngx_http_auth_spnego_precontent_preserve(ngx_http_request_t *r);
 
 #if (NGX_PCRE)
 static char *ngx_conf_set_regex_array_slot(ngx_conf_t *cf, ngx_command_t *cmd,
@@ -533,6 +534,13 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *cf) {
 
     *h = ngx_http_auth_spnego_handler;
 
+    h = ngx_array_push(&cmcf->phases[NGX_HTTP_PRECONTENT_PHASE].handlers);
+    if (NULL == h) {
+        return NGX_ERROR;
+    }
+
+    *h = ngx_http_auth_spnego_precontent_preserve;
+
     ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
     if (ngx_http_auth_spnego_add_variable(cf, &var_name) != NGX_OK) {
         return NGX_ERROR;
@@ -651,60 +659,89 @@ ngx_http_auth_spnego_mutual_token_present(ngx_http_request_t *r)
     return 0;
 }
 
+static ngx_uint_t
+ngx_http_auth_spnego_is_negotiate_mutual_value(ngx_str_t *value)
+{
+    size_t  prefix;
+
+    prefix = sizeof("Negotiate ") - 1;
+
+    return value->len > prefix
+           && ngx_strncmp(value->data, "Negotiate ", prefix) == 0;
+}
+
 /* nginx satisfy any clears WWW-Authenticate via hash=0; restore for Negotiate */
 static void
 ngx_http_auth_spnego_restore_mutual_auth_headers(ngx_http_request_t *r)
 {
-    ngx_table_elt_t  *h;
-    size_t            prefix;
+    ngx_list_part_t  *part;
+    ngx_table_elt_t  *header, *h;
+    ngx_uint_t        i;
+    size_t            key_len;
 
-    prefix = sizeof("Negotiate ") - 1;
+    key_len = sizeof("WWW-Authenticate") - 1;
 
     for (h = r->headers_out.www_authenticate; h; h = h->next) {
-        if (h->hash != 0 || h->value.len <= prefix) {
-            continue;
+        if (h->hash == 0
+            && ngx_http_auth_spnego_is_negotiate_mutual_value(&h->value))
+        {
+            h->hash = 1;
+        }
+    }
+
+    part = &r->headers_out.headers.part;
+    header = part->elts;
+
+    for (i = 0; /* void */; i++) {
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+
+            part = part->next;
+            header = part->elts;
+            i = 0;
         }
 
-        if (ngx_strncmp(h->value.data, "Negotiate ", prefix) == 0) {
-            h->hash = 1;
+        if (header[i].hash == 0
+            && header[i].key.len == key_len
+            && ngx_strncasecmp(header[i].key.data, (u_char *) "WWW-Authenticate",
+                               key_len) == 0
+            && ngx_http_auth_spnego_is_negotiate_mutual_value(&header[i].value))
+        {
+            header[i].hash = 1;
         }
     }
 }
 
 static ngx_int_t
-ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
+ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r)
 {
     ngx_http_auth_spnego_ctx_t       *ctx;
     ngx_http_auth_spnego_loc_conf_t  *alcf;
     ngx_str_t                         value;
 
-    if (r != r->main) {
-        return ngx_http_next_header_filter(r);
-    }
-
     alcf = ngx_http_get_module_loc_conf(r, ngx_http_auth_spnego_module);
     if (alcf == NULL || alcf->protect == 0 || alcf->preserve_mutual_auth == 0) {
-        return ngx_http_next_header_filter(r);
+        return NGX_DECLINED;
     }
 
-    /* status may still be 0 here for a 200 from return/content; only skip
-     * explicit non-2xx responses */
     if (r->headers_out.status != 0
         && (r->headers_out.status < NGX_HTTP_OK
             || r->headers_out.status >= NGX_HTTP_SPECIAL_RESPONSE))
     {
-        return ngx_http_next_header_filter(r);
+        return NGX_DECLINED;
     }
 
     ngx_http_auth_spnego_restore_mutual_auth_headers(r);
 
     if (ngx_http_auth_spnego_mutual_token_present(r)) {
-        return ngx_http_next_header_filter(r);
+        return NGX_DECLINED;
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_auth_spnego_module);
     if (ctx == NULL || ctx->token_out_b64.len == 0) {
-        return ngx_http_next_header_filter(r);
+        return NGX_DECLINED;
     }
 
     value.len = sizeof("Negotiate ") - 1 + ctx->token_out_b64.len;
@@ -716,6 +753,40 @@ ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
     ngx_snprintf(value.data, value.len, "Negotiate %V", &ctx->token_out_b64);
 
     if (ngx_http_auth_spnego_add_www_authenticate(r, &value, 1) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    return NGX_DECLINED;
+}
+
+static ngx_int_t
+ngx_http_auth_spnego_precontent_preserve(ngx_http_request_t *r)
+{
+    ngx_int_t  rc;
+
+    if (r != r->main) {
+        return NGX_DECLINED;
+    }
+
+    rc = ngx_http_auth_spnego_preserve_mutual_auth(r);
+    if (rc == NGX_ERROR) {
+        return NGX_ERROR;
+    }
+
+    return NGX_DECLINED;
+}
+
+static ngx_int_t
+ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
+{
+    ngx_int_t  rc;
+
+    if (r != r->main) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    rc = ngx_http_auth_spnego_preserve_mutual_auth(r);
+    if (rc == NGX_ERROR) {
         return NGX_ERROR;
     }
 

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -70,7 +70,9 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *);
 
 static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
 static ngx_int_t ngx_http_auth_spnego_header_filter(ngx_http_request_t *r);
-static ngx_int_t ngx_http_auth_spnego_precontent_preserve(ngx_http_request_t *r);
+static ngx_int_t ngx_http_auth_spnego_add_www_authenticate(ngx_http_request_t *r,
+                                                            ngx_str_t *value,
+                                                            ngx_uint_t hash);
 
 #if (NGX_PCRE)
 static char *ngx_conf_set_regex_array_slot(ngx_conf_t *cf, ngx_command_t *cmd,
@@ -121,9 +123,6 @@ typedef struct {
     ngx_str_t token_out_b64; /* base64 encoded output tokent */
 } ngx_http_auth_spnego_ctx_t;
 
-static ngx_http_auth_spnego_ctx_t *
-ngx_http_auth_spnego_get_ctx(ngx_http_request_t *r);
-
 typedef struct {
     ngx_flag_t protect;
     ngx_str_t realm;
@@ -145,7 +144,6 @@ typedef struct {
     ngx_flag_t map_to_local;
     ngx_flag_t delegate_credentials;
     ngx_flag_t constrained_delegation;
-    ngx_flag_t preserve_mutual_auth;
 } ngx_http_auth_spnego_loc_conf_t;
 
 static void ngx_http_auth_spnego_strip_realm(ngx_http_request_t *,
@@ -214,10 +212,6 @@ static ngx_command_t ngx_http_auth_spnego_commands[] = {
     {ngx_string("auth_gss_constrained_delegation"), SPNEGO_NGX_CONF_FLAGS,
      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
      offsetof(ngx_http_auth_spnego_loc_conf_t, constrained_delegation), NULL},
-
-    {ngx_string("auth_gss_preserve_mutual_auth"), SPNEGO_NGX_CONF_FLAGS,
-     ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
-     offsetof(ngx_http_auth_spnego_loc_conf_t, preserve_mutual_auth), NULL},
 
     ngx_null_command};
 
@@ -321,7 +315,6 @@ static void *ngx_http_auth_spnego_create_loc_conf(ngx_conf_t *cf) {
     conf->map_to_local = NGX_CONF_UNSET;
     conf->delegate_credentials = NGX_CONF_UNSET;
     conf->constrained_delegation = NGX_CONF_UNSET;
-    conf->preserve_mutual_auth = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -417,8 +410,6 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
                              prev->delegate_credentials, 0);
     ngx_conf_merge_off_value(conf->constrained_delegation,
                              prev->constrained_delegation, 0);
-    ngx_conf_merge_off_value(conf->preserve_mutual_auth,
-                             prev->preserve_mutual_auth, 1);
 
 #if (NGX_DEBUG)
     ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0, "auth_spnego: protect = %i",
@@ -537,13 +528,6 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *cf) {
 
     *h = ngx_http_auth_spnego_handler;
 
-    h = ngx_array_push(&cmcf->phases[NGX_HTTP_PRECONTENT_PHASE].handlers);
-    if (NULL == h) {
-        return NGX_ERROR;
-    }
-
-    *h = ngx_http_auth_spnego_precontent_preserve;
-
     ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
     if (ngx_http_auth_spnego_add_variable(cf, &var_name) != NGX_OK) {
         return NGX_ERROR;
@@ -639,135 +623,16 @@ ngx_http_auth_spnego_headers(ngx_http_request_t *r,
     return NGX_OK;
 }
 
-static ngx_uint_t
-ngx_http_auth_spnego_mutual_token_present(ngx_http_request_t *r)
+static ngx_int_t
+ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
 {
-    ngx_table_elt_t  *h;
-    size_t            prefix;
-
-    prefix = sizeof("Negotiate ") - 1;
-
-    for (h = r->headers_out.www_authenticate; h; h = h->next) {
-        if (h->hash == 0 || h->value.len <= prefix) {
-            continue;
-        }
-
-        if (ngx_strncmp(h->value.data, "Negotiate ", prefix) == 0
-            && h->value.len > prefix)
-        {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-static ngx_http_auth_spnego_ctx_t *
-ngx_http_auth_spnego_get_ctx(ngx_http_request_t *r)
-{
-    ngx_http_auth_spnego_ctx_t  *ctx;
-    ngx_http_request_t          *auth_r;
+    ngx_http_auth_spnego_ctx_t *ctx;
+    ngx_str_t                   value;
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_auth_spnego_module);
-    if (ctx != NULL) {
-        return ctx;
-    }
 
-    auth_r = r;
-    while (auth_r->parent) {
-        auth_r = auth_r->parent;
-    }
-
-    if (auth_r != r) {
-        return ngx_http_get_module_ctx(auth_r, ngx_http_auth_spnego_module);
-    }
-
-    return NULL;
-}
-
-static ngx_uint_t
-ngx_http_auth_spnego_is_negotiate_mutual_value(ngx_str_t *value)
-{
-    size_t  prefix;
-
-    prefix = sizeof("Negotiate ") - 1;
-
-    return value->len > prefix
-           && ngx_strncmp(value->data, "Negotiate ", prefix) == 0;
-}
-
-/* nginx satisfy any clears WWW-Authenticate via hash=0; restore for Negotiate */
-static void
-ngx_http_auth_spnego_restore_mutual_auth_headers(ngx_http_request_t *r)
-{
-    ngx_list_part_t  *part;
-    ngx_table_elt_t  *header, *h;
-    ngx_uint_t        i;
-    size_t            key_len;
-
-    key_len = sizeof("WWW-Authenticate") - 1;
-
-    for (h = r->headers_out.www_authenticate; h; h = h->next) {
-        if (h->hash == 0
-            && ngx_http_auth_spnego_is_negotiate_mutual_value(&h->value))
-        {
-            h->hash = 1;
-        }
-    }
-
-    part = &r->headers_out.headers.part;
-    header = part->elts;
-
-    for (i = 0; /* void */; i++) {
-        if (i >= part->nelts) {
-            if (part->next == NULL) {
-                break;
-            }
-
-            part = part->next;
-            header = part->elts;
-            i = 0;
-        }
-
-        if (header[i].hash == 0
-            && header[i].key.len == key_len
-            && ngx_strncasecmp(header[i].key.data, (u_char *) "WWW-Authenticate",
-                               key_len) == 0
-            && ngx_http_auth_spnego_is_negotiate_mutual_value(&header[i].value))
-        {
-            header[i].hash = 1;
-        }
-    }
-}
-
-static ngx_int_t
-ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r)
-{
-    ngx_http_auth_spnego_ctx_t       *ctx;
-    ngx_http_auth_spnego_loc_conf_t  *alcf;
-    ngx_str_t                         value;
-
-    alcf = ngx_http_get_module_loc_conf(r, ngx_http_auth_spnego_module);
-    if (alcf == NULL || alcf->protect == 0 || alcf->preserve_mutual_auth == 0) {
-        return NGX_DECLINED;
-    }
-
-    if (r->headers_out.status != 0
-        && (r->headers_out.status < NGX_HTTP_OK
-            || r->headers_out.status >= NGX_HTTP_SPECIAL_RESPONSE))
-    {
-        return NGX_DECLINED;
-    }
-
-    ngx_http_auth_spnego_restore_mutual_auth_headers(r);
-
-    if (ngx_http_auth_spnego_mutual_token_present(r)) {
-        return NGX_DECLINED;
-    }
-
-    ctx = ngx_http_auth_spnego_get_ctx(r);
-    if (ctx == NULL || ctx->token_out_b64.len == 0) {
-        return NGX_DECLINED;
+    if (ctx == NULL || ctx->ret != NGX_OK || ctx->token_out_b64.len == 0) {
+        return ngx_http_next_header_filter(r);
     }
 
     value.len = sizeof("Negotiate ") - 1 + ctx->token_out_b64.len;
@@ -775,44 +640,9 @@ ngx_http_auth_spnego_preserve_mutual_auth(ngx_http_request_t *r)
     if (value.data == NULL) {
         return NGX_ERROR;
     }
-
     ngx_snprintf(value.data, value.len, "Negotiate %V", &ctx->token_out_b64);
 
     if (ngx_http_auth_spnego_add_www_authenticate(r, &value, 1) != NGX_OK) {
-        return NGX_ERROR;
-    }
-
-    return NGX_DECLINED;
-}
-
-static ngx_int_t
-ngx_http_auth_spnego_precontent_preserve(ngx_http_request_t *r)
-{
-    ngx_int_t  rc;
-
-    if (r != r->main) {
-        return NGX_DECLINED;
-    }
-
-    rc = ngx_http_auth_spnego_preserve_mutual_auth(r);
-    if (rc == NGX_ERROR) {
-        return NGX_ERROR;
-    }
-
-    return NGX_DECLINED;
-}
-
-static ngx_int_t
-ngx_http_auth_spnego_header_filter(ngx_http_request_t *r)
-{
-    ngx_int_t  rc;
-
-    if (r != r->main) {
-        return ngx_http_next_header_filter(r);
-    }
-
-    rc = ngx_http_auth_spnego_preserve_mutual_auth(r);
-    if (rc == NGX_ERROR) {
         return NGX_ERROR;
     }
 
@@ -1985,15 +1815,10 @@ static ngx_int_t ngx_http_auth_spnego_handler(ngx_http_request_t *r) {
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_auth_spnego_module);
     if (NULL == ctx) {
-        ctx = ngx_palloc(r->pool, sizeof(ngx_http_auth_spnego_ctx_t));
+        ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_auth_spnego_ctx_t));
         if (NULL == ctx) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
-        ctx->token.len = 0;
-        ctx->token.data = NULL;
-        ctx->token_out_b64.len = 0;
-        ctx->token_out_b64.data = NULL;
-        ctx->head = 0;
         ctx->ret = NGX_HTTP_UNAUTHORIZED;
         ngx_http_set_ctx(r, ctx, ngx_http_auth_spnego_module);
     }
@@ -2076,25 +1901,24 @@ static ngx_int_t ngx_http_auth_spnego_handler(ngx_http_request_t *r) {
         spnego_debug0("GSSAPI auth succeeded");
     }
 
-    ngx_str_t *token_out_b64 = NULL;
     switch (ret) {
     case NGX_DECLINED: /* DECLINED, but not yet FORBIDDEN */
         ctx->ret = NGX_HTTP_UNAUTHORIZED;
+        if (NGX_ERROR == ngx_http_auth_spnego_headers(r, ctx, NULL, alcf)) {
+            spnego_debug0("Error setting headers");
+            ctx->ret = NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
         break;
     case NGX_OK:
         ctx->ret = NGX_OK;
-        token_out_b64 = &ctx->token_out_b64;
+        /* WWW-Authenticate: Negotiate <token> is emitted by the output header
+         * filter, which runs after nginx's satisfy-any WWW-Authenticate
+         * cleanup, so the mutual-auth token survives satisfy any. */
         break;
     case NGX_ERROR:
     default:
         ctx->ret = NGX_HTTP_INTERNAL_SERVER_ERROR;
         break;
-    }
-
-    if (NGX_ERROR ==
-        ngx_http_auth_spnego_headers(r, ctx, token_out_b64, alcf)) {
-        spnego_debug0("Error setting headers");
-        ctx->ret = NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
     spnego_debug3("SSO auth handling OUT: token.len=%d, head=%d, ret=%d",

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -796,9 +796,9 @@ test_basic "fallback.php" 401 200
 test_path "fallback.php" 401 403
 test_path "noauth.php" 200 200
 test_path "auth.php" 401 200
-test_path "delegate.php" 401 200
-test_preserve_mutual_auth
-test_ldapwhoami "alice"
+	test_path "delegate.php" 401 200
+	test_ldapwhoami "alice"
+	test_preserve_mutual_auth
 
 
 echo ""

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -754,7 +754,7 @@ test_preserve_mutual_auth()
 
 test_ldapwhoami()
 {
-	LDAP_EXPECTED="dn:uid=${1},cn=gssapi,cn=auth"
+	LDAP_EXPECTED="dn:uid=${1},cn=gss-spnego,cn=auth"
 
 	printf "Result of ldapwhoami via delegation ... "
 	if [ -e "${CURL_OUTPUT}" ]; then

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -754,7 +754,7 @@ test_preserve_mutual_auth()
 
 test_ldapwhoami()
 {
-	LDAP_EXPECTED="dn:uid=${1},cn=gss-spnego,cn=auth"
+	LDAP_EXPECTED="dn:uid=${1},cn=gssapi,cn=auth"
 
 	printf "Result of ldapwhoami via delegation ... "
 	if [ -e "${CURL_OUTPUT}" ]; then

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -450,6 +450,30 @@ server {
                 auth_gss_delegate_credentials on;
                 auth_gss_constrained_delegation on;
 	}
+
+	location = /satisfy-preserve-on {
+		satisfy any;
+		auth_gss on;
+		auth_gss_realm ${KERBEROS_REALM};
+		auth_gss_keytab /etc/krb5.http.keytab;
+		auth_gss_service_name HTTP/${TEST_HOST_FQDN};
+		auth_gss_allow_basic_fallback off;
+		auth_gss_preserve_mutual_auth on;
+		default_type text/plain;
+		return 200 "OK\n";
+	}
+
+	location = /satisfy-preserve-off {
+		satisfy any;
+		auth_gss on;
+		auth_gss_realm ${KERBEROS_REALM};
+		auth_gss_keytab /etc/krb5.http.keytab;
+		auth_gss_service_name HTTP/${TEST_HOST_FQDN};
+		auth_gss_allow_basic_fallback off;
+		auth_gss_preserve_mutual_auth off;
+		default_type text/plain;
+		return 200 "OK\n";
+	}
 }
 EOF
 then
@@ -656,6 +680,67 @@ test_basic()
 
 }
 
+curl_negotiate_final_has_mutual_token()
+{
+	URL="$1"
+	HDRS_FILE="${CURL_OUTPUT}.headers"
+
+	rm -f "${HDRS_FILE}"
+	CODE="$(curl --max-time 60 --negotiate -u : -s -D "${HDRS_FILE}" -o "${CURL_OUTPUT}" \
+		-w "%{http_code}" "${URL}")" || CODE="000"
+
+	if [ "${CODE}" != "200" ]; then
+		return 1
+	fi
+
+	awk '
+		/^HTTP\// {
+			if (in200 && block ~ /WWW-Authenticate: Negotiate [A-Za-z0-9+\/=]+/)
+				found = 1
+			in200 = ($2 == 200)
+			block = ""
+			next
+		}
+		in200 { block = block $0 ORS }
+		END {
+			if (in200 && block ~ /WWW-Authenticate: Negotiate [A-Za-z0-9+\/=]+/)
+				found = 1
+			exit(found ? 0 : 1
+		}
+	' "${HDRS_FILE}"
+}
+
+test_preserve_mutual_auth()
+{
+	printf "satisfy any + preserve on (expect mutual token on 200) ... "
+	if curl_negotiate_final_has_mutual_token \
+		"http://${TEST_HOST_FQDN}:8080/satisfy-preserve-on"; then
+		echo "OK"
+	else
+		EX=1
+		echo "FAILED"
+		if [ -e "${CURL_OUTPUT}.headers" ]; then
+			echo "Final response headers:"
+			cat "${CURL_OUTPUT}.headers"
+			echo ""
+		fi
+	fi
+
+	printf "satisfy any + preserve off (expect no mutual token on 200) ... "
+	if curl_negotiate_final_has_mutual_token \
+		"http://${TEST_HOST_FQDN}:8080/satisfy-preserve-off"; then
+		EX=1
+		echo "FAILED (token present but should be stripped)"
+		if [ -e "${CURL_OUTPUT}.headers" ]; then
+			echo "Final response headers:"
+			cat "${CURL_OUTPUT}.headers"
+			echo ""
+		fi
+	else
+		echo "OK"
+	fi
+}
+
 test_ldapwhoami()
 {
 	LDAP_EXPECTED="dn:uid=${1},cn=gss-spnego,cn=auth"
@@ -701,6 +786,7 @@ test_path "fallback.php" 401 403
 test_path "noauth.php" 200 200
 test_path "auth.php" 401 200
 test_path "delegate.php" 401 200
+test_preserve_mutual_auth
 test_ldapwhoami "alice"
 
 

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -448,7 +448,7 @@ server {
                 fastcgi_param KRB5CCNAME \$krb5_cc_name;
                 auth_gss_service_ccache /tmp/krb5cc_nginx;
                 auth_gss_delegate_credentials on;
-                auth_gss_constrained_delegation on;
+		auth_gss_constrained_delegation on;
 	}
 
 	location = /satisfy-preserve-on {
@@ -460,7 +460,7 @@ server {
 		auth_gss_allow_basic_fallback off;
 		auth_gss_preserve_mutual_auth on;
 		default_type text/plain;
-		return 200 "OK\n";
+		alias /var/www/kerberos/satisfy-preserve-on.txt;
 	}
 
 	location = /satisfy-preserve-off {
@@ -472,7 +472,7 @@ server {
 		auth_gss_allow_basic_fallback off;
 		auth_gss_preserve_mutual_auth off;
 		default_type text/plain;
-		return 200 "OK\n";
+		alias /var/www/kerberos/satisfy-preserve-off.txt;
 	}
 }
 EOF
@@ -524,6 +524,15 @@ if ! cat <<'EOF' > /var/www/kerberos/fallback.php
 	echo("Authenticated as " . $_SERVER["REMOTE_USER"]);
 ?>
 EOF
+then
+	die
+fi
+echo "OK"
+
+
+printf "Writing satisfy-preserve test bodies ... "
+if ! printf 'OK\n' > /var/www/kerberos/satisfy-preserve-on.txt \
+	|| ! printf 'OK\n' > /var/www/kerberos/satisfy-preserve-off.txt
 then
 	die
 fi

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -451,28 +451,13 @@ server {
 		auth_gss_constrained_delegation on;
 	}
 
-	location = /satisfy-preserve-on {
+	location /satisfyany {
 		satisfy any;
 		auth_gss on;
 		auth_gss_realm ${KERBEROS_REALM};
 		auth_gss_keytab /etc/krb5.http.keytab;
 		auth_gss_service_name HTTP/${TEST_HOST_FQDN};
 		auth_gss_allow_basic_fallback off;
-		auth_gss_preserve_mutual_auth on;
-		default_type text/plain;
-		alias /var/www/kerberos/satisfy-preserve-on.txt;
-	}
-
-	location = /satisfy-preserve-off {
-		satisfy any;
-		auth_gss on;
-		auth_gss_realm ${KERBEROS_REALM};
-		auth_gss_keytab /etc/krb5.http.keytab;
-		auth_gss_service_name HTTP/${TEST_HOST_FQDN};
-		auth_gss_allow_basic_fallback off;
-		auth_gss_preserve_mutual_auth off;
-		default_type text/plain;
-		alias /var/www/kerberos/satisfy-preserve-off.txt;
 	}
 }
 EOF
@@ -530,13 +515,8 @@ fi
 echo "OK"
 
 
-printf "Writing satisfy-preserve test bodies ... "
-if ! printf 'OK\n' > /var/www/kerberos/satisfy-preserve-on.txt \
-	|| ! printf 'OK\n' > /var/www/kerberos/satisfy-preserve-off.txt
-then
-	die
-fi
-echo "OK"
+printf "Writing satisfyany static file ... "
+echo "OK" > /var/www/kerberos/satisfyany && echo "OK" || die
 
 
 printf "Writing delegate.php ... "
@@ -689,67 +669,25 @@ test_basic()
 
 }
 
-curl_negotiate_final_has_mutual_token()
+test_negotiate_token()
 {
-	URL="$1"
-	HDRS_FILE="${CURL_OUTPUT}.headers"
+	SUBURL="$1"
+	TMPHEADERS="$(mktemp)"
 
-	rm -f "${HDRS_FILE}"
-	CODE="$(curl --max-time 60 --negotiate -u : -s -D "${HDRS_FILE}" -o "${CURL_OUTPUT}" \
-		-w "%{http_code}" "${URL}")" || CODE="000"
+	printf "curl %s, negotiate: WWW-Authenticate token in 200=" "${SUBURL}"
+	rm -f "${CURL_OUTPUT}"
+	$CURL_NEGOTIATE -D "${TMPHEADERS}" -o "${CURL_OUTPUT}" \
+		"http://${TEST_HOST_FQDN}:8080/${SUBURL}" || true
 
-	if [ "${CODE}" != "200" ]; then
-		return 1
-	fi
-
-	awk '
-		/^HTTP\// {
-			if (in200 && block ~ /WWW-Authenticate: Negotiate [A-Za-z0-9+\/=]+/)
-				found = 1
-			in200 = ($2 == 200)
-			block = ""
-			next
-		}
-		in200 { block = block $0 ORS }
-		END {
-			if (in200 && block ~ /WWW-Authenticate: Negotiate [A-Za-z0-9+\/=]+/)
-				found = 1
-			if (found)
-				exit 0
-			exit 1
-		}
-	' "${HDRS_FILE}"
-}
-
-test_preserve_mutual_auth()
-{
-	printf "satisfy any + preserve on (expect mutual token on 200) ... "
-	if curl_negotiate_final_has_mutual_token \
-		"http://${TEST_HOST_FQDN}:8080/satisfy-preserve-on"; then
+	# -D captures headers from all responses (401 then 200); the 401 has
+	# "Negotiate" with no token, the 200 should have "Negotiate <token>".
+	if grep -qi "^WWW-Authenticate: Negotiate [A-Za-z0-9+/]" "${TMPHEADERS}"; then
 		echo "OK"
 	else
 		EX=1
 		echo "FAILED"
-		if [ -e "${CURL_OUTPUT}.headers" ]; then
-			echo "Final response headers:"
-			cat "${CURL_OUTPUT}.headers"
-			echo ""
-		fi
 	fi
-
-	printf "satisfy any + preserve off (expect no mutual token on 200) ... "
-	if curl_negotiate_final_has_mutual_token \
-		"http://${TEST_HOST_FQDN}:8080/satisfy-preserve-off"; then
-		EX=1
-		echo "FAILED (token present but should be stripped)"
-		if [ -e "${CURL_OUTPUT}.headers" ]; then
-			echo "Final response headers:"
-			cat "${CURL_OUTPUT}.headers"
-			echo ""
-		fi
-	else
-		echo "OK"
-	fi
+	rm -f "${TMPHEADERS}"
 }
 
 test_ldapwhoami()
@@ -798,7 +736,8 @@ test_path "noauth.php" 200 200
 test_path "auth.php" 401 200
 	test_path "delegate.php" 401 200
 	test_ldapwhoami "alice"
-	test_preserve_mutual_auth
+	test_path "satisfyany" 401 200
+	test_negotiate_token "satisfyany"
 
 
 echo ""

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -705,7 +705,9 @@ curl_negotiate_final_has_mutual_token()
 		END {
 			if (in200 && block ~ /WWW-Authenticate: Negotiate [A-Za-z0-9+\/=]+/)
 				found = 1
-			exit(found ? 0 : 1
+			if (found)
+				exit 0
+			exit 1
 		}
 	' "${HDRS_FILE}"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #146.

When `satisfy any` is configured, nginx's access phase zeroes the hash of every `WWW-Authenticate` header as soon as any access handler returns `NGX_OK`, which strips the `Negotiate <token>` needed for SPNEGO mutual authentication ([nginx/nginx#861](https://github.com/nginx/nginx/issues/861)).

## Approach

Aligned with [PR #178](https://github.com/stnoonan/spnego-http-auth-nginx-module/pull/178) (mutual-auth commit only; channel bindings remain separate):

- On **success**, store the GSS output token in `ctx->token_out_b64` and add `WWW-Authenticate: Negotiate <token>` in an **output header filter** (runs after satisfy-any cleanup).
- On **401**, set challenge headers (`Negotiate`, optional `Basic`) in the access handler as before.
- Initialize request ctx with `ngx_pcalloc` so `token_out_b64.len` is never uninitialized.

## Also in this PR (not in #178)

- **GSS mutual-auth token handling**: accept `GSS_S_CONTINUE_NEEDED` when an output token is present; optional second `gss_accept_sec_context` when `GSS_C_MUTUAL_FLAG` is set but no token on the first accept.
- **`ngx_http_auth_spnego_store_output_token()`** helper for encoding the MIC token.

## Tests

- `location /satisfyany` with `satisfy any` and static file
- `test_negotiate_token` asserts `WWW-Authenticate: Negotiate <base64>` on the 200 response

## Removed (previous iteration)

- `auth_gss_preserve_mutual_auth` directive
- PRECONTENT phase handler and hash-restore loops
- preserve on/off test locations

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24bb1ad8-6b97-4db3-a01a-a50764244c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24bb1ad8-6b97-4db3-a01a-a50764244c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

