### PR TITLE
Draft: Add support for MEMORY: ccaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,29 +88,70 @@ If you would like to enable GSS local name rules to rewrite usernames, you can
 specify the `auth_gss_map_to_local` option.
 
 Credential Delegation
------------------------------
+---------------------
 
-User credentials can be delegated to nginx using the `auth_gss_delegate_credentials` 
- directive. This directive will enable unconstrained delegation if the user chooses 
- to delegate their credentials. Constrained delegation (S4U2proxy) can also be enabled using the 
- `auth_gss_constrained_delegation` directive together with the `auth_gss_delegate_credentials` 
- directive. To specify the ccache file name to store the service ticket used for constrained 
- delegation, set the `auth_gss_service_ccache` directive. Otherwise, the default ccache name 
- will be used.
+User credentials can be delegated to nginx using the `auth_gss_delegate_credentials`
+directive. It accepts three values:
 
-    auth_gss_service_ccache /tmp/krb5cc_0;
+* `off` — delegation disabled (default).
+* `on` — delegated credentials are written to a temporary ccache file under the
+  system tmp directory and exposed via the `$krb5_cc_name` nginx variable.
+* `export` — delegated credentials are exported in-memory via `gss_export_cred()`,
+  base64-encoded, and exposed via the `$krb5_cred_exported` nginx variable.  No
+  file is written.  See the Security Considerations section below before using
+  this mode.
+
+Constrained delegation (S4U2Proxy) can be enabled with the
+`auth_gss_constrained_delegation` directive alongside `auth_gss_delegate_credentials`.
+`auth_gss_service_ccache` specifies the ccache file used to hold the server's own
+TGT for S4U2Proxy; if omitted, the process default ccache is used.
+
+**File-based mode** (`on`):
+
+    auth_gss_service_ccache /tmp/krb5cc_nginx;
     auth_gss_delegate_credentials on;
     auth_gss_constrained_delegation on;
-
-The delegated credentials will be stored within the systems tmp directory. Once the
- request is completed, the credentials file will be destroyed. The name of the credentials 
- file will be specified within the nginx variable `$krb5_cc_name`. Usage of the variable 
- can include passing it to a fcgi program using the `fastcgi_param` directive.
-
     fastcgi_param KRB5CCNAME $krb5_cc_name;
 
-Constrained delegation is currently only supported using the negotiate authentication scheme
- and has only been testing with MIT Kerberos (Use at your own risk if using Heimdal Kerberos).
+The delegated credentials file is destroyed once the request completes.
+
+**Export mode** (`export`):
+
+    auth_gss_service_ccache /tmp/krb5cc_nginx;
+    auth_gss_delegate_credentials export;
+    auth_gss_constrained_delegation on;
+    fastcgi_param KRB5_CRED_EXPORTED $krb5_cred_exported;
+
+No per-request file is created.  The credential blob is passed directly to the
+FastCGI backend as a base64-encoded parameter.
+
+Constrained delegation is currently only supported using the Negotiate authentication
+scheme and has only been tested with MIT Kerberos (use at your own risk with Heimdal).
+
+Security Considerations for Export Mode
+----------------------------------------
+
+Export mode eliminates the temporary ccache file under `/tmp`, removing the risk of
+credential files being read by other local processes, TOCTOU races, and orphaned
+files left behind on worker crashes.  However, it introduces its own tradeoffs:
+
+**Debug logging.**  When nginx is compiled with `--with-debug` and
+`error_log ... debug` is active, nginx logs FastCGI parameters at debug level.
+This includes `KRB5_CRED_EXPORTED`, which contains a live, base64-encoded Kerberos
+credential blob.  Anyone with access to the error log can extract and use it.
+**Do not enable debug-level logging in production when using export mode.**
+
+**Backend transport.**  The credential blob travels over the FastCGI/uwsgi/SCGI
+connection between nginx and the backend.  Use a Unix socket for this
+connection.  A cleartext TCP socket — even on loopback — allows any process on
+the host with sufficient privilege (e.g. packet capture) to intercept the
+credential.
+
+**FastCGI buffer size.**  An exported Kerberos credential is typically 2–8 KB of
+binary data, which becomes 3–11 KB when base64-encoded.  If nginx's
+`fastcgi_buffer_size` is at its default of 4 KB you may need to increase it:
+
+    fastcgi_buffer_size 16k;
 
 Basic authentication fallback
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Constrained delegation (S4U2Proxy) can be enabled with the
 `auth_gss_constrained_delegation` directive alongside `auth_gss_delegate_credentials`.
 `auth_gss_service_ccache` specifies the ccache file used to hold the server's own
 TGT for S4U2Proxy; if omitted, the process default ccache is used.
+`auth_gss_service_ccache_memory on` replaces the file-based service ccache with
+an in-memory ccache; see the Service Ccache section below.
 
 **File-based mode** (`on`):
 
@@ -125,8 +127,51 @@ The delegated credentials file is destroyed once the request completes.
 No per-request file is created.  The credential blob is passed directly to the
 FastCGI backend as a base64-encoded parameter.
 
+**Fully file-free mode** (export + memory service ccache):
+
+    auth_gss_service_ccache_memory on;
+    auth_gss_delegate_credentials export;
+    auth_gss_constrained_delegation on;
+    fastcgi_param KRB5_CRED_EXPORTED $krb5_cred_exported;
+
+No files are written at any point.  See the Service Credential Cache and
+Security Considerations sections below.
+
 Constrained delegation is currently only supported using the Negotiate authentication
 scheme and has only been tested with MIT Kerberos (use at your own risk with Heimdal).
+
+
+Service Credential Cache
+------------------------
+
+When `auth_gss_service_ccache_memory on` is set, the HTTP service principal's
+TGT is held in a per-worker in-memory ccache rather than a file.  The
+`auth_gss_service_ccache` file path directive is then ignored.
+
+Each nginx worker maintains one MEMORY ccache per service principal.  Because
+MEMORY ccaches are per-process (not shared between workers), each worker
+independently checks its own ccache and fetches a new TGT from the keytab when
+needed.  When a TGT expires all N workers each make one independent TGS-REQ
+rather than one worker doing it for all.  For typical TGT lifetimes (24 h) and
+worker counts (4–16), this is negligible.
+
+**Security tradeoffs.**
+
+*Improvements over file-based service ccache:*
+
+* The TGT never appears on disk; there is no file to read or steal.
+* No predictable filename for an attacker to target.
+* The TGT vanishes automatically when a worker exits — no orphaned files.
+* Per-worker isolation: a memory-disclosure exploit affecting one worker does
+  not expose the TGT of any other worker.
+
+*Considerations:*
+
+* If nginx worker processes generate core dumps (disabled by default via
+  `setrlimit(RLIMIT_CORE, 0)`) the TGT would be present in the dump.
+* On nginx restart or graceful reload every worker must fetch a fresh TGT from
+  the KDC.  With file-based ccaches a valid TGT can survive a restart.
+
 
 Security Considerations for Export Mode
 ----------------------------------------

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -45,6 +45,7 @@
 #endif
 
 #define CCACHE_VARIABLE_NAME "krb5_cc_name"
+#define CRED_EXPORT_VARIABLE_NAME "krb5_cred_exported"
 #define SHM_ZONE_NAME "shm_zone"
 #define RENEWAL_TIME 60
 
@@ -52,6 +53,11 @@
 #define NGX_HTTP_AUTH_SPNEGO_CB_OFF       0
 #define NGX_HTTP_AUTH_SPNEGO_CB_SERVER_EP 1
 #define NGX_HTTP_AUTH_SPNEGO_CB_EXPORTER  2
+
+/* Values for the auth_gss_delegate_credentials tri-state directive. */
+#define NGX_HTTP_AUTH_SPNEGO_DELEGATE_OFF    0
+#define NGX_HTTP_AUTH_SPNEGO_DELEGATE_ON     1
+#define NGX_HTTP_AUTH_SPNEGO_DELEGATE_EXPORT 2
 
 
 #define spnego_log_krb5_error(context, code)                                   \
@@ -86,7 +92,6 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *);
 static char *ngx_conf_set_regex_array_slot(ngx_conf_t *cf, ngx_command_t *cmd,
                                            void *conf);
 #endif
-
 ngx_int_t ngx_http_auth_spnego_set_bogus_authorization(ngx_http_request_t *r);
 static ngx_int_t ngx_http_auth_spnego_header_filter(ngx_http_request_t *r);
 static ngx_int_t ngx_http_auth_spnego_add_www_authenticate(ngx_http_request_t *r,
@@ -155,7 +160,7 @@ typedef struct {
     ngx_array_t *auth_princs_regex;
 #endif
     ngx_flag_t map_to_local;
-    ngx_flag_t delegate_credentials;
+    ngx_uint_t delegate_credentials;  /* NGX_HTTP_AUTH_SPNEGO_DELEGATE_* */
     ngx_flag_t constrained_delegation;
     ngx_uint_t channel_binding;       /* NGX_HTTP_AUTH_SPNEGO_CB_* */
 } ngx_http_auth_spnego_loc_conf_t;
@@ -166,6 +171,13 @@ static void ngx_http_auth_spnego_strip_realm(ngx_http_request_t *,
 #define SPNEGO_NGX_CONF_FLAGS                                                  \
     NGX_HTTP_MAIN_CONF                                                         \
     | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_FLAG
+
+static const ngx_conf_enum_t ngx_http_auth_spnego_delegate_creds[] = {
+    { ngx_string("off"),    NGX_HTTP_AUTH_SPNEGO_DELEGATE_OFF },
+    { ngx_string("on"),     NGX_HTTP_AUTH_SPNEGO_DELEGATE_ON },
+    { ngx_string("export"), NGX_HTTP_AUTH_SPNEGO_DELEGATE_EXPORT },
+    { ngx_null_string, 0 }
+};
 
 static const ngx_conf_enum_t ngx_http_auth_spnego_cb[] = {
     { ngx_string("off"),              NGX_HTTP_AUTH_SPNEGO_CB_OFF },
@@ -228,9 +240,12 @@ static ngx_command_t ngx_http_auth_spnego_commands[] = {
      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
      offsetof(ngx_http_auth_spnego_loc_conf_t, map_to_local), NULL},
 
-    {ngx_string("auth_gss_delegate_credentials"), SPNEGO_NGX_CONF_FLAGS,
-     ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
-     offsetof(ngx_http_auth_spnego_loc_conf_t, delegate_credentials), NULL},
+    {ngx_string("auth_gss_delegate_credentials"),
+     NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF
+         | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_enum_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_auth_spnego_loc_conf_t, delegate_credentials),
+     (void *) &ngx_http_auth_spnego_delegate_creds},
 
     {ngx_string("auth_gss_constrained_delegation"), SPNEGO_NGX_CONF_FLAGS,
      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
@@ -343,7 +358,7 @@ static void *ngx_http_auth_spnego_create_loc_conf(ngx_conf_t *cf) {
     conf->auth_princs_regex = NGX_CONF_UNSET_PTR;
 #endif
     conf->map_to_local = NGX_CONF_UNSET;
-    conf->delegate_credentials = NGX_CONF_UNSET;
+    conf->delegate_credentials = NGX_CONF_UNSET_UINT;
     conf->constrained_delegation = NGX_CONF_UNSET;
     conf->channel_binding = NGX_CONF_UNSET_UINT;
 
@@ -437,8 +452,9 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
 
     ngx_conf_merge_off_value(conf->map_to_local, prev->map_to_local, 0);
 
-    ngx_conf_merge_off_value(conf->delegate_credentials,
-                             prev->delegate_credentials, 0);
+    ngx_conf_merge_uint_value(conf->delegate_credentials,
+                              prev->delegate_credentials,
+                              NGX_HTTP_AUTH_SPNEGO_DELEGATE_OFF);
     ngx_conf_merge_off_value(conf->constrained_delegation,
                              prev->constrained_delegation, 0);
     ngx_conf_merge_uint_value(conf->channel_binding,
@@ -491,7 +507,7 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
                        conf->map_to_local);
 
     ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0,
-                       "auth_spnego: delegate_credentials = %i",
+                       "auth_spnego: delegate_credentials = %ui",
                        conf->delegate_credentials);
 
     ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0,
@@ -570,6 +586,11 @@ static ngx_int_t ngx_http_auth_spnego_init(ngx_conf_t *cf) {
 
     ngx_str_t var_name = ngx_string(CCACHE_VARIABLE_NAME);
     if (ngx_http_auth_spnego_add_variable(cf, &var_name) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    ngx_str_t export_var_name = ngx_string(CRED_EXPORT_VARIABLE_NAME);
+    if (ngx_http_auth_spnego_add_variable(cf, &export_var_name) != NGX_OK) {
         return NGX_ERROR;
     }
 
@@ -989,6 +1010,91 @@ ngx_http_auth_spnego_realm_from_str(ngx_str_t s, size_t *realm_len)
     return at + 1;
 }
 
+/*
+ * Export delegated GSS credentials in base64-encoded form as
+ * $krb5_cred_exported.
+ */
+static ngx_int_t
+ngx_http_auth_spnego_export_delegated_creds(ngx_http_request_t *r,
+                                            gss_cred_id_t delegated_creds)
+{
+    OM_uint32 major_status, minor_status;
+    gss_buffer_desc token = GSS_C_EMPTY_BUFFER;
+    ngx_str_t raw, b64, var_name;
+
+    if (delegated_creds == GSS_C_NO_CREDENTIAL) {
+        spnego_debug0("export_delegated_creds: client did not delegate "
+                      "credentials");
+        return NGX_OK;
+    }
+
+    major_status = gss_export_cred(&minor_status, delegated_creds, &token);
+    if (GSS_ERROR(major_status)) {
+        spnego_log_error("%s", get_gss_error(r->pool, minor_status,
+                                             "gss_export_cred() failed"));
+        return NGX_ERROR;
+    }
+
+    raw.data = (u_char *)token.value;
+    raw.len  = token.length;
+
+    b64.len  = ngx_base64_encoded_length(raw.len);
+    b64.data = ngx_pcalloc(r->pool, b64.len + 1);
+    if (b64.data == NULL) {
+        gss_release_buffer(&minor_status, &token);
+        return NGX_ERROR;
+    }
+
+    ngx_encode_base64(&b64, &raw);
+    gss_release_buffer(&minor_status, &token);
+
+    var_name = (ngx_str_t)ngx_string(CRED_EXPORT_VARIABLE_NAME);
+    return ngx_http_auth_spnego_set_variable(r, &var_name, &b64);
+}
+
+/*
+ * Convert a krb5_creds into a gss_cred_id_t via a temporary MEMORY ccache,
+ * then export it into $krb5_cred_exported.
+ */
+static ngx_int_t
+ngx_http_auth_spnego_export_krb5_creds(ngx_http_request_t *r,
+                                        krb5_context kcontext,
+                                        krb5_principal principal,
+                                        krb5_creds *creds)
+{
+    krb5_ccache ccache = NULL;
+    krb5_error_code kerr;
+    gss_cred_id_t gss_creds = GSS_C_NO_CREDENTIAL;
+    OM_uint32 major_status, minor_status;
+    ngx_int_t ret = NGX_ERROR;
+
+    if ((kerr = krb5_cc_new_unique(kcontext, "MEMORY", NULL, &ccache))) {
+        spnego_log_error("Kerberos error: Cannot create MEMORY ccache");
+        spnego_log_krb5_error(kcontext, kerr);
+        goto done;
+    }
+
+    if ((kerr = ngx_http_auth_spnego_store_krb5_creds(r, kcontext, principal,
+                                                      ccache, *creds)))
+        goto done;
+
+    major_status = gss_krb5_import_cred(&minor_status, ccache, NULL, NULL,
+                                        &gss_creds);
+    if (GSS_ERROR(major_status)) {
+        spnego_log_error("%s", get_gss_error(r->pool, minor_status,
+                                             "gss_krb5_import_cred() failed"));
+        goto done;
+    }
+
+    ret = ngx_http_auth_spnego_export_delegated_creds(r, gss_creds);
+
+done:
+    if (gss_creds != GSS_C_NO_CREDENTIAL)
+        gss_release_cred(&minor_status, &gss_creds);
+    if (ccache)
+        krb5_cc_destroy(kcontext, ccache);
+    return ret;
+}
 
 ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
                                      ngx_http_auth_spnego_ctx_t *ctx,
@@ -1201,9 +1307,15 @@ ngx_int_t ngx_http_auth_spnego_basic(ngx_http_request_t *r,
         spnego_error(NGX_DECLINED);
     }
 
-    if (alcf->delegate_credentials) {
+    if (alcf->delegate_credentials == NGX_HTTP_AUTH_SPNEGO_DELEGATE_ON) {
         creds_info delegated_creds = {&creds, TYPE_KRB5_CREDS};
         ngx_http_auth_spnego_store_delegated_creds(r, name, delegated_creds);
+    } else if (alcf->delegate_credentials == NGX_HTTP_AUTH_SPNEGO_DELEGATE_EXPORT) {
+        if (ngx_http_auth_spnego_export_krb5_creds(r, kcontext, client,
+                                                    &creds) != NGX_OK) {
+            krb5_free_cred_contents(kcontext, &creds);
+            spnego_error(NGX_ERROR);
+        }
     }
 
     krb5_free_cred_contents(kcontext, &creds);
@@ -1876,7 +1988,7 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
         ngx_memcpy(username, output_token.value, output_token.length);
         username[output_token.length] = '\0';
 
-        if (alcf->delegate_credentials) {
+        if (alcf->delegate_credentials == NGX_HTTP_AUTH_SPNEGO_DELEGATE_ON) {
             creds_info creds = {delegated_creds, TYPE_GSS_CRED_ID_T};
             ngx_http_auth_spnego_store_delegated_creds(r, username, creds);
         }
@@ -1891,6 +2003,17 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
         }
         spnego_debug1("user is %V", &r->headers_in.user);
     }
+
+    if (alcf->delegate_credentials == NGX_HTTP_AUTH_SPNEGO_DELEGATE_EXPORT) {
+        /* Export must be the last operation on delegated_creds before the
+         * gss_release_cred() in the end: block below (see RFC 5588 note in
+         * ngx_http_auth_spnego_export_delegated_creds). */
+        if (ngx_http_auth_spnego_export_delegated_creds(r,
+                                                   delegated_creds) != NGX_OK) {
+            spnego_error(NGX_ERROR);
+        }
+    }
+
 
     gss_release_buffer(&minor_status, &output_token);
     output_token = (gss_buffer_desc)GSS_C_EMPTY_BUFFER;

--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -163,6 +163,7 @@ typedef struct {
     ngx_uint_t delegate_credentials;  /* NGX_HTTP_AUTH_SPNEGO_DELEGATE_* */
     ngx_flag_t constrained_delegation;
     ngx_uint_t channel_binding;       /* NGX_HTTP_AUTH_SPNEGO_CB_* */
+    ngx_flag_t service_ccache_memory;
 } ngx_http_auth_spnego_loc_conf_t;
 
 static void ngx_http_auth_spnego_strip_realm(ngx_http_request_t *,
@@ -257,6 +258,10 @@ static ngx_command_t ngx_http_auth_spnego_commands[] = {
      ngx_conf_set_enum_slot, NGX_HTTP_LOC_CONF_OFFSET,
      offsetof(ngx_http_auth_spnego_loc_conf_t, channel_binding),
      (void *) &ngx_http_auth_spnego_cb},
+
+    {ngx_string("auth_gss_service_ccache_memory"), SPNEGO_NGX_CONF_FLAGS,
+     ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_auth_spnego_loc_conf_t, service_ccache_memory), NULL},
 
     ngx_null_command};
 
@@ -361,6 +366,7 @@ static void *ngx_http_auth_spnego_create_loc_conf(ngx_conf_t *cf) {
     conf->delegate_credentials = NGX_CONF_UNSET_UINT;
     conf->constrained_delegation = NGX_CONF_UNSET;
     conf->channel_binding = NGX_CONF_UNSET_UINT;
+    conf->service_ccache_memory = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -401,8 +407,10 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
     ngx_conf_merge_off_value(conf->protect, prev->protect, 0);
     ngx_conf_merge_str_value(conf->shm_zone_name, prev->shm_zone_name,
                              SHM_ZONE_NAME);
+    ngx_conf_merge_off_value(conf->service_ccache_memory,
+                             prev->service_ccache_memory, 0);
 
-    if (conf->protect != 0) {
+    if (conf->protect != 0 && !conf->service_ccache_memory) {
         if (ngx_http_auth_spnego_create_shm_zone(cf, &conf->shm_zone_name) !=
             NGX_OK) {
             ngx_conf_log_error(
@@ -460,7 +468,6 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
     ngx_conf_merge_uint_value(conf->channel_binding,
                               prev->channel_binding,
                               NGX_HTTP_AUTH_SPNEGO_CB_OFF);
-
 #if (NGX_DEBUG)
     ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0, "auth_spnego: protect = %i",
                        conf->protect);
@@ -516,6 +523,10 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
     ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0,
                        "auth_spnego: channel_binding = %ui",
                        conf->channel_binding);
+
+    ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0,
+                       "auth_spnego: service_ccache_memory = %i",
+                       conf->service_ccache_memory);
 #endif
 
     return NGX_CONF_OK;
@@ -1548,7 +1559,8 @@ done:
 
 static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(
     ngx_http_request_t *r, const char *service_name,
-    const char *keytab_prefix_path, const char *service_ccache_prefix_path) {
+    const char *keytab_prefix_path, const char *service_ccache_prefix_path,
+    ngx_flag_t use_memory) {
     krb5_context kcontext = NULL;
     krb5_keytab keytab = NULL;
     krb5_ccache ccache = NULL;
@@ -1560,6 +1572,8 @@ static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(
     char *tgs_principal_name = NULL;
     const char *cc_name = NULL;
     OM_uint32 gss_minor;
+    ngx_slab_pool_t *shpool = NULL;
+    int locked = 0;
 
     memset(&creds, 0, sizeof(creds));
 
@@ -1569,7 +1583,27 @@ static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(
         goto done;
     }
 
-    if (service_ccache_prefix_path != NULL) {
+    if (use_memory) {
+        /*
+         * Per-worker MEMORY ccache named after the service principal.
+         * No cross-worker mutex is needed: each worker manages its own.
+         */
+        size_t needed = ngx_strlen("MEMORY:nginx_svc_") + ngx_strlen(service_name) + 1;
+        char *name = ngx_palloc(r->pool, needed);
+        if (name == NULL) {
+            kerr = ENOMEM;
+            goto done;
+        }
+        ngx_snprintf((u_char *)name, needed, "MEMORY:nginx_svc_%s%Z", service_name);
+        cc_name = name;
+
+        if ((kerr = krb5_cc_resolve(kcontext, cc_name, &ccache))) {
+            spnego_log_error("Kerberos error: Cannot resolve MEMORY ccache %s",
+                             cc_name);
+            spnego_log_krb5_error(kcontext, kerr);
+            goto done;
+        }
+    } else if (service_ccache_prefix_path != NULL) {
         cc_name = service_ccache_prefix_path;
         if ((kerr = krb5_cc_resolve(kcontext, cc_name, &ccache))) {
             spnego_log_error("Kerberos error: Cannot resolve ccache %s",
@@ -1594,7 +1628,8 @@ static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(
 
     if ((kerr = ngx_http_auth_spnego_verify_server_credentials(
              r, kcontext, service_name, ccache))) {
-        if (kerr == KRB5_FCC_NOFILE || kerr == KRB5KRB_AP_ERR_TKT_EXPIRED) {
+        if (kerr == KRB5_FCC_NOFILE || kerr == KRB5_CC_NOTFOUND
+            || kerr == KRB5KRB_AP_ERR_TKT_EXPIRED) {
             if ((kerr = krb5_parse_name(kcontext, service_name, &principal))) {
                 spnego_log_error("Kerberos error: Cannot parse principal %s",
                                  service_name);
@@ -1618,14 +1653,20 @@ static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(
         goto done;
     }
 
-    ngx_slab_pool_t *shpool = (ngx_slab_pool_t *)shm_zone->shm.addr;
+    if (!use_memory) {
+        /*
+         * FILE mode: lock the cross-worker mutex and verify once more before
+         * doing the KDC round-trip, so only one worker refreshes at a time.
+         */
+        shpool = (ngx_slab_pool_t *)shm_zone->shm.addr;
+        ngx_shmtx_lock(&shpool->mutex);
+        locked = 1;
 
-    ngx_shmtx_lock(&shpool->mutex);
-
-    kerr = ngx_http_auth_spnego_verify_server_credentials(r, kcontext,
-                                                          service_name, ccache);
-    if ((kerr != KRB5_FCC_NOFILE && kerr != KRB5KRB_AP_ERR_TKT_EXPIRED))
-        goto unlock;
+        kerr = ngx_http_auth_spnego_verify_server_credentials(r, kcontext,
+                                                              service_name, ccache);
+        if ((kerr != KRB5_FCC_NOFILE && kerr != KRB5KRB_AP_ERR_TKT_EXPIRED))
+            goto unlock;
+    }
 
     if ((kerr = krb5_kt_resolve(kcontext, keytab_prefix_path, &keytab))) {
         spnego_log_error("Kerberos error: Cannot resolve keytab %s",
@@ -1668,7 +1709,8 @@ static ngx_int_t ngx_http_auth_spnego_obtain_server_credentials(
     }
 
 unlock:
-    ngx_shmtx_unlock(&shpool->mutex);
+    if (locked)
+        ngx_shmtx_unlock(&shpool->mutex);
 done:
     if (!kerr) {
         spnego_debug0("Successfully obtained server credentials");
@@ -1879,7 +1921,7 @@ ngx_http_auth_spnego_auth_user_gss(ngx_http_request_t *r,
         if (alcf->constrained_delegation) {
             ngx_http_auth_spnego_obtain_server_credentials(
                 r, (char *)service.value, alcf->keytab_prefix_path,
-                alcf->service_ccache_prefix_path);
+                alcf->service_ccache_prefix_path, alcf->service_ccache_memory);
         }
 
         /* Obtain credentials */

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -486,6 +486,25 @@ server {
                 auth_gss_delegate_credentials export;
 	}
 
+	# Tests auth_gss_service_ccache_memory: identical to delegate.php except
+	# the service TGT lives in a per-worker MEMORY ccache instead of a file.
+	location /delegate_mem.php {
+		include snippets/fastcgi-php.conf;
+		fastcgi_pass unix:/run/php/php-fpm.sock;
+                auth_gss on;
+                auth_gss_realm ${KERBEROS_REALM};
+                auth_gss_keytab /etc/krb5.http.keytab;
+                auth_gss_service_name HTTP/${TEST_HOST_FQDN};
+                auth_gss_allow_basic_fallback off;
+                auth_gss_authorized_principal alice@${KERBEROS_REALM};
+                auth_gss_format_full on;
+                fastcgi_param HTTP_AUTHORIZATION "";
+                fastcgi_param KRB5CCNAME \$krb5_cc_name;
+                auth_gss_service_ccache_memory on;
+                auth_gss_delegate_credentials on;
+                auth_gss_constrained_delegation on;
+	}
+
 	# Channel binding directive on plain HTTP: no TLS session exists so the
 	# module fails with a 500 error.
 	location /cbinding_sep.php {
@@ -730,6 +749,63 @@ then
 fi
 echo "OK"
 
+
+printf "Writing delegate_mem.php ... "
+if ! cat <<EOF > /var/www/kerberos/delegate_mem.php
+<?php
+	if (!isset(\$_SERVER["REMOTE_USER"]) || \$_SERVER["REMOTE_USER"] == "") {
+		http_response_code(500);
+		echo("REMOTE_USER not set");
+		exit();
+	}
+
+	if (!isset(\$_SERVER["KRB5CCNAME"]) || \$_SERVER["KRB5CCNAME"] == "") {
+		http_response_code(500);
+		echo("KRB5CCNAME not set");
+		exit();
+	}
+
+	putenv("KRB5CCNAME=" . \$_SERVER['KRB5CCNAME']);
+
+	\$conn = ldap_connect("ldap://${TEST_HOST_FQDN}/");
+	if (!\$conn) {
+		http_response_code(500);
+		echo("ldap_connect() failed");
+		exit();
+	}
+
+	if (!ldap_set_option(\$conn, LDAP_OPT_PROTOCOL_VERSION, 3)) {
+		http_response_code(500);
+		echo("ldap_set_option() failed");
+		exit();
+	}
+
+	\$r = ldap_sasl_bind(\$conn);
+	if (!\$r) {
+		http_response_code(500);
+		echo("ldap_sasl_bind() failed: " . ldap_error(\$conn));
+		if (ldap_get_option(\$conn, LDAP_OPT_DIAGNOSTIC_MESSAGE, \$ext_err)) {
+			echo(" (" . \$ext_err . ")");
+		}
+		exit();
+	}
+
+	\$who = ldap_exop_whoami(\$conn);
+	if (!\$who) {
+		http_response_code(500);
+		echo("ldap_exop_whoami() failed");
+		exit();
+	}
+
+	echo(\$who);
+?>
+EOF
+then
+	die
+fi
+echo "OK"
+
+
 # For example, if php-fpm was already running when libsasl2-modules-gssapi-mit
 # was installed, it won't pick up the new GSSAPI capabilities until it has been
 # restarted...so let's restart all services that might use SASL/GSSAPI in our
@@ -953,6 +1029,7 @@ test_path "noauth.php" 200 200
 test_path "auth.php" 401 401
 test_path "delegate.php" 401 401
 test_path "export_check.php" 401 401
+test_path "delegate_mem.php" 401 401
 
 
 echo ""
@@ -973,6 +1050,8 @@ test_path "satisfyany" 401 200
 test_negotiate_token "satisfyany"
 test_path "export_check.php" 401 200 "${CURL_NEGOTIATE_DELEGATE}"
 test_export_check "alice"
+test_path "delegate_mem.php" 401 200
+test_ldapwhoami "alice"
 
 
 echo ""
@@ -990,6 +1069,7 @@ test_path "noauth.php" 200 200
 test_path "auth.php" 401 403
 test_path "delegate.php" 401 403
 test_path "export_check.php" 401 403
+test_path "delegate_mem.php" 401 403
 
 
 echo ""
@@ -1007,6 +1087,7 @@ test_path "noauth.php" 200 200
 test_path "auth.php" 401 403
 test_path "delegate.php" 401 403
 test_path "export_check.php" 401 403
+test_path "delegate_mem.php" 401 403
 
 
 echo ""
@@ -1028,6 +1109,7 @@ kdestroy -q > /dev/null 2>&1 || true
 echo "OK"
 test_path "delegate.php" 401 401
 test_path "export_check.php" 401 401
+test_path "delegate_mem.php" 401 401
 
 
 echo ""
@@ -1043,6 +1125,7 @@ test_path "delegate.php" 401 500
 # does not affect it — the user's forwarded credential is still exported.
 test_path "export_check.php" 401 200 "${CURL_NEGOTIATE_DELEGATE}"
 test_export_check "alice"
+test_path "delegate_mem.php" 401 500
 
 
 echo ""
@@ -1056,6 +1139,7 @@ else
 fi
 test_path "delegate.php" 401 403
 test_path "export_check.php" 401 403
+test_path "delegate_mem.php" 401 403
 
 echo ""
 printf "Re-adding delegation permissions via LDAP ... "
@@ -1084,6 +1168,8 @@ test_path "delegate.php" 401 200
 test_ldapwhoami "alice"
 test_path "export_check.php" 401 200 "${CURL_NEGOTIATE_DELEGATE}"
 test_export_check "alice"
+test_path "delegate_mem.php" 401 200
+test_ldapwhoami "alice"
 
 
 echo ""

--- a/scripts/kerberos_ldap
+++ b/scripts/kerberos_ldap
@@ -18,6 +18,7 @@ EX=0
 CURL_OUTPUT="http_body"
 CURL_NONEGOTIATE="curl --max-time 60 --silent --fail-with-body -o ${CURL_OUTPUT}"
 CURL_NEGOTIATE="${CURL_NONEGOTIATE} --negotiate -u :"
+CURL_NEGOTIATE_DELEGATE="${CURL_NEGOTIATE} --delegation policy"
 CURL_HTTPS_NONEGOTIATE="${CURL_NONEGOTIATE} --insecure"
 CURL_HTTPS_NEGOTIATE="${CURL_NEGOTIATE} --insecure"
 HTTPS_PORT="8443"
@@ -464,6 +465,27 @@ server {
                 auth_gss_constrained_delegation on;
 	}
 
+	# Tests auth_gss_delegate_credentials export: credentials are serialised
+	# via gss_export_cred() and delivered as a FastCGI parameter rather than
+	# written to a file.  No constrained delegation is configured here; the
+	# client forwards credentials directly because +ok_as_delegate is set on
+	# the HTTP principal and curl uses its default delegation policy.
+	location /export_check.php {
+		include snippets/fastcgi-php.conf;
+		fastcgi_pass unix:/run/php/php-fpm.sock;
+                auth_gss on;
+                auth_gss_realm ${KERBEROS_REALM};
+                auth_gss_keytab /etc/krb5.http.keytab;
+                auth_gss_service_name HTTP/${TEST_HOST_FQDN};
+                auth_gss_allow_basic_fallback off;
+                auth_gss_authorized_principal alice@${KERBEROS_REALM};
+                auth_gss_format_full on;
+                fastcgi_param HTTP_AUTHORIZATION "";
+                fastcgi_param KRB5_CRED_EXPORTED \$krb5_cred_exported;
+                fastcgi_param KRB5CCNAME \$krb5_cc_name;
+                auth_gss_delegate_credentials export;
+	}
+
 	# Channel binding directive on plain HTTP: no TLS session exists so the
 	# module fails with a 500 error.
 	location /cbinding_sep.php {
@@ -675,6 +697,39 @@ echo "OK"
 
 printf "Writing satisfyany static file ... "
 echo "OK" > /var/www/kerberos/satisfyany && echo "OK" || die
+
+printf "Writing export_check.php ... "
+if ! cat <<'EOF' > /var/www/kerberos/export_check.php
+<?php
+	if (!isset($_SERVER["REMOTE_USER"]) || $_SERVER["REMOTE_USER"] == "") {
+		http_response_code(500);
+		echo("REMOTE_USER not set");
+		exit();
+	}
+	if (!isset($_SERVER["KRB5_CRED_EXPORTED"]) || $_SERVER["KRB5_CRED_EXPORTED"] == "") {
+		http_response_code(500);
+		echo("KRB5_CRED_EXPORTED not set");
+		exit();
+	}
+	if (isset($_SERVER["KRB5CCNAME"]) && $_SERVER["KRB5CCNAME"] != "") {
+		http_response_code(500);
+		echo("KRB5CCNAME unexpectedly set in export mode: " . $_SERVER["KRB5CCNAME"]);
+		exit();
+	}
+	$blob = base64_decode($_SERVER["KRB5_CRED_EXPORTED"], true);
+	if ($blob === false || strlen($blob) == 0) {
+		http_response_code(500);
+		echo("KRB5_CRED_EXPORTED is not valid base64");
+		exit();
+	}
+	echo("Export credentials valid for " . $_SERVER["REMOTE_USER"]);
+?>
+EOF
+then
+	die
+fi
+echo "OK"
+
 # For example, if php-fpm was already running when libsasl2-modules-gssapi-mit
 # was installed, it won't pick up the new GSSAPI capabilities until it has been
 # restarted...so let's restart all services that might use SASL/GSSAPI in our
@@ -695,6 +750,7 @@ test_path()
 	SUBURL="$1"
 	EXPECT1="$2"
 	EXPECT2="$3"
+	CURL_NEG="${4:-${CURL_NEGOTIATE}}"
 
 	printf "curl %s, no negotiate: http status (expect %s)=" "${SUBURL}" "${EXPECT1}"
 	rm -f "${CURL_OUTPUT}"
@@ -714,7 +770,7 @@ test_path()
 
 	printf "curl %s, negotiate: http status (expect %s)=" "${SUBURL}" "${EXPECT2}"
 	rm -f "${CURL_OUTPUT}"
-	CODE="$($CURL_NEGOTIATE -w "%{http_code}" "http://${TEST_HOST_FQDN}:8080/${SUBURL}")" || true
+	CODE="$($CURL_NEG -w "%{http_code}" "http://${TEST_HOST_FQDN}:8080/${SUBURL}")" || true
 	printf "%s ... " "${CODE}"
 	if [ "$CODE" = "${EXPECT2}" ]; then
 		echo "OK"
@@ -866,6 +922,28 @@ test_negotiate_token()
 }
 
 
+test_export_check()
+{
+	EXPORT_EXPECTED="Export credentials valid for ${1}@${KERBEROS_REALM}"
+
+	printf "Export credential blob valid for %s ... " "${1}"
+	if [ -e "${CURL_OUTPUT}" ]; then
+		EXPORT_RESULT="$(cat "${CURL_OUTPUT}")"
+		if [ "${EXPORT_RESULT}" != "${EXPORT_EXPECTED}" ]; then
+			printf "%s != %s ... " "${EXPORT_RESULT}" "${EXPORT_EXPECTED}"
+			EX=1
+			echo "FAILED"
+		else
+			printf "%s ... " "${EXPORT_RESULT}"
+			echo "OK"
+		fi
+	else
+		EX=1
+		echo "FAILED"
+	fi
+}
+
+
 printf "Destroying Kerberos tickets ... "
 kdestroy -q > /dev/null 2>&1 || true
 echo "OK"
@@ -874,6 +952,7 @@ test_path "fallback.php" 401 401
 test_path "noauth.php" 200 200
 test_path "auth.php" 401 401
 test_path "delegate.php" 401 401
+test_path "export_check.php" 401 401
 
 
 echo ""
@@ -892,6 +971,8 @@ test_path "delegate.php" 401 200
 test_ldapwhoami "alice"
 test_path "satisfyany" 401 200
 test_negotiate_token "satisfyany"
+test_path "export_check.php" 401 200 "${CURL_NEGOTIATE_DELEGATE}"
+test_export_check "alice"
 
 
 echo ""
@@ -908,6 +989,7 @@ test_path "fallback.php" 401 403
 test_path "noauth.php" 200 200
 test_path "auth.php" 401 403
 test_path "delegate.php" 401 403
+test_path "export_check.php" 401 403
 
 
 echo ""
@@ -924,6 +1006,7 @@ test_path "fallback.php" 401 200
 test_path "noauth.php" 200 200
 test_path "auth.php" 401 403
 test_path "delegate.php" 401 403
+test_path "export_check.php" 401 403
 
 
 echo ""
@@ -944,6 +1027,7 @@ printf "Destroying Kerberos tickets ... "
 kdestroy -q > /dev/null 2>&1 || true
 echo "OK"
 test_path "delegate.php" 401 401
+test_path "export_check.php" 401 401
 
 
 echo ""
@@ -955,6 +1039,10 @@ else
 	echo "FAILED"
 fi
 test_path "delegate.php" 401 500
+# export_check has no constrained delegation so krbAllowedToDelegateTo removal
+# does not affect it — the user's forwarded credential is still exported.
+test_path "export_check.php" 401 200 "${CURL_NEGOTIATE_DELEGATE}"
+test_export_check "alice"
 
 
 echo ""
@@ -967,6 +1055,7 @@ else
 	echo "FAILED"
 fi
 test_path "delegate.php" 401 403
+test_path "export_check.php" 401 403
 
 echo ""
 printf "Re-adding delegation permissions via LDAP ... "
@@ -993,6 +1082,8 @@ else
 fi
 test_path "delegate.php" 401 200
 test_ldapwhoami "alice"
+test_path "export_check.php" 401 200 "${CURL_NEGOTIATE_DELEGATE}"
+test_export_check "alice"
 
 
 echo ""


### PR DESCRIPTION
Two commits to add support for in-memory ccaches for service and delegated credentials (instead of using `FILE:` style ccaches, meaning nothing is written to the file system).

Draft for now, I'm not really happy with the module options yet (I think we might want to move to some kind of custom `auth_gss_delegation` variable that can take `none`, `unconstrained`, `constrained`, `both` and a separate variable to define the kind of `ccache` to use, `memory`/`file`/`gssproxy`).

The rough plan for now is that `MEMORY:` would become mandatory in the future for the service ccache (which would make it possible to remove `SHM` pools, mutexes, and all code that deals with `FILE:` type service ccaches), with `gssproxy` as a supported (and preferred) alternative, and then steering users towards only configuring no/constrained delegation in combination with `gssproxy`. But that needs some more exploration to determine the feasibility first.