### PR TITLE
spnego: gate config-time checks on auth_gss being enabled

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -453,14 +453,14 @@ static char *ngx_http_auth_spnego_merge_loc_conf(ngx_conf_t *cf, void *parent,
         krb5_free_context(kctx);
     }
 
-    if (!conf->realm.len && conf->allow_basic) {
+    if (conf->protect && !conf->realm.len && conf->allow_basic) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                            "auth_gss_allow_basic_fallback requires "
                            "auth_gss_realm or a default_realm in krb5.conf");
         return NGX_CONF_ERROR;
     }
 
-    if (conf->srvcname.len || conf->allow_basic) {
+    if (conf->protect && (conf->srvcname.len || conf->allow_basic)) {
         ngx_http_core_srv_conf_t *cscf =
             ((ngx_http_conf_ctx_t *)cf->ctx)
                 ->srv_conf[ngx_http_core_module.ctx_index];


### PR DESCRIPTION
The realm validation and service principal construction added in ed7386f run unconditionally for every location config.  Since allow_basic defaults to on, any location that does not explicitly set auth_gss_allow_basic_fallback off — including locations that never use auth_gss at all — would fail at startup if no default realm is present in krb5.conf.

Guard both checks with conf->protect so they only apply to locations where auth_gss is actually enabled.

Fixes: #183